### PR TITLE
Main options for dropdown

### DIFF
--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -9,6 +9,7 @@ use RuntimeException;
 use Yiisoft\Arrays\ArrayHelper;
 use Yiisoft\Definitions\Exception\InvalidConfigException;
 use Yiisoft\Html\Html;
+use Yiisoft\Html\Tag\Li;
 
 use function array_key_exists;
 use function array_merge;
@@ -39,6 +40,8 @@ final class Dropdown extends Widget
     private bool $encodeTags = false;
     private array $submenuOptions = [];
     private array $options = [];
+    private array $itemOptions = [];
+    private array $linkOptions = [];
 
     protected function run(): string
     {
@@ -127,6 +130,36 @@ final class Dropdown extends Widget
     }
 
     /**
+     * Options for each item if not present in self
+     *
+     * @param array $options
+     *
+     * @return self
+     */
+    public function itemOptions(array $options): self
+    {
+        $new = clone $this;
+        $new->itemOptions = $options;
+
+        return $new;
+    }
+
+    /**
+     * Options for each item link if not present in current item
+     *
+     * @param array $options
+     *
+     * @return self
+     */
+    public function linkOptions(array $options): self
+    {
+        $new = clone $this;
+        $new->linkOptions = $options;
+
+        return $new;
+    }
+
+    /**
      * Renders menu items.
      *
      * @param array $items the menu items to be rendered
@@ -154,75 +187,93 @@ final class Dropdown extends Widget
                 throw new RuntimeException("The 'label' option is required.");
             }
 
-            $encodeLabel = $item['encode'] ?? $this->encodeLabels;
-            $label = $encodeLabel ? Html::encode($item['label']) : $item['label'];
-            $itemOptions = ArrayHelper::getValue($item, 'options', []);
-            $linkOptions = ArrayHelper::getValue($item, 'linkOptions', []);
-            $active = ArrayHelper::getValue($item, 'active', false);
-            $disabled = ArrayHelper::getValue($item, 'disabled', false);
-            $enclose = ArrayHelper::getValue($item, 'enclose', true);
-
-            Html::addCssClass($linkOptions, ['widget' => 'dropdown-item']);
-
-            if ($disabled) {
-                ArrayHelper::setValue($linkOptions, 'tabindex', '-1');
-                ArrayHelper::setValue($linkOptions, 'aria-disabled', 'true');
-                Html::addCssClass($linkOptions, ['disable' => 'disabled']);
-            } elseif ($active) {
-                Html::addCssClass($linkOptions, ['active' => 'active']);
-            }
-
-            $url = $item['url'] ?? null;
-
-            /** @psalm-suppress ConflictingReferenceConstraint */
-            if (empty($item['items'])) {
-                if ($label === '-') {
-                    $content = Html::div('', ['class' => 'dropdown-divider']);
-                } elseif ($enclose === false) {
-                    $content = $label;
-                } elseif ($url === null) {
-                    $content = Html::tag('h6', $label, ['class' => 'dropdown-header']);
-                } else {
-                    $content = Html::a($label, $url, $linkOptions)->encode($this->encodeTags);
-                }
-
-                $lines[] = $content;
-            } else {
-                $submenuOptions = $this->submenuOptions;
-
-                if (isset($item['submenuOptions'])) {
-                    $submenuOptions = array_merge($submenuOptions, $item['submenuOptions']);
-                }
-
-                Html::addCssClass($submenuOptions, ['submenu' => 'dropdown-menu']);
-                Html::addCssClass($linkOptions, ['toggle' => 'dropdown-toggle']);
-
-                $itemOptions = array_merge_recursive(['class' => ['dropdown'], 'aria-expanded' => 'false'], $itemOptions);
-
-                $dropdown = self::widget()
-                    ->items($item['items'])
-                    ->options($submenuOptions)
-                    ->submenuOptions($submenuOptions);
-
-                if ($this->encodeLabels === false) {
-                    $dropdown = $dropdown->withoutEncodeLabels();
-                }
-
-                ArrayHelper::setValue($linkOptions, 'data-bs-toggle', 'dropdown');
-                ArrayHelper::setValue($linkOptions, 'aria-haspopup', 'true');
-                ArrayHelper::setValue($linkOptions, 'aria-expanded', 'false');
-                ArrayHelper::setValue($linkOptions, 'role', 'button');
-
-                $lines[] = Html::a($label, $url, $linkOptions)->encode($this->encodeTags) .
-                    Html::tag('ul', $dropdown->render(), $itemOptions)->encode($this->encodeTags);
-            }
+            $lines[] = $this->renderItem($item);
         }
 
         $options = array_merge(['aria-expanded' => 'false'], $options);
 
         return Html::ul()
-            ->strings($lines, [], $this->encodeTags)
+            ->items(...$lines)
             ->attributes($options)
             ->render();
+    }
+
+    /**
+     * Render current dropdown item
+     *
+     * @param array $item
+     *
+     * @return Li
+     */
+    private function renderItem(array $item): Li
+    {
+        $url = $item['url'] ?? null;
+        $encodeLabel = $item['encode'] ?? $this->encodeLabels;
+        $label = $encodeLabel ? Html::encode($item['label']) : $item['label'];
+        $itemOptions = ArrayHelper::getValue($item, 'options', $this->itemOptions);
+        $linkOptions = ArrayHelper::getValue($item, 'linkOptions', $this->linkOptions);
+        $active = ArrayHelper::getValue($item, 'active', false);
+        $disabled = ArrayHelper::getValue($item, 'disabled', false);
+        $enclose = ArrayHelper::getValue($item, 'enclose', true);
+
+        if ($url !== null || !empty($item['items'])) {
+            Html::addCssClass($linkOptions, ['widget' => 'dropdown-item']);
+        }
+
+        if ($disabled) {
+            ArrayHelper::setValue($linkOptions, 'tabindex', '-1');
+            ArrayHelper::setValue($linkOptions, 'aria-disabled', 'true');
+            Html::addCssClass($linkOptions, ['disable' => 'disabled']);
+        } elseif ($active) {
+            Html::addCssClass($linkOptions, ['active' => 'active']);
+        }
+
+        /** @psalm-suppress ConflictingReferenceConstraint */
+        if (empty($item['items'])) {
+            if ($url !== null) {
+                $content = Html::a($label, $url, $linkOptions)->encode($this->encodeTags);
+            } elseif ($label === '-') {
+                Html::addCssClass($linkOptions, ['widget' => 'dropdown-divider']);
+                $content = Html::tag('hr', null, $linkOptions);
+            } elseif ($enclose === false) {
+                $content = $label;
+            } else {
+                $tag = ArrayHelper::remove($linkOptions, 'tag', 'h6');
+                Html::addCssClass($linkOptions, ['widget' => 'dropdown-header']);
+                $content = Html::tag($tag, $label, $linkOptions);
+            }
+
+            return Li::tag()->content($content)->attributes($itemOptions)->encode(false);
+        }
+
+        $submenuOptions = $this->submenuOptions;
+
+        if (isset($item['submenuOptions'])) {
+            $submenuOptions = array_merge($submenuOptions, $item['submenuOptions']);
+        }
+
+        Html::addCssClass($submenuOptions, ['submenu' => 'dropdown-menu']);
+        Html::addCssClass($linkOptions, ['toggle' => 'dropdown-toggle']);
+
+        $itemOptions = array_merge_recursive(['class' => ['dropdown'], 'aria-expanded' => 'false'], $itemOptions);
+
+        $dropdown = self::widget()
+                    ->items($item['items'])
+                    ->options($submenuOptions)
+                    ->submenuOptions($submenuOptions);
+
+        if ($this->encodeLabels === false) {
+            $dropdown = $dropdown->withoutEncodeLabels();
+        }
+
+        ArrayHelper::setValue($linkOptions, 'data-bs-toggle', 'dropdown');
+        ArrayHelper::setValue($linkOptions, 'aria-haspopup', 'true');
+        ArrayHelper::setValue($linkOptions, 'aria-expanded', 'false');
+        ArrayHelper::setValue($linkOptions, 'role', 'button');
+
+        $toggle = Html::a($label, $url, $linkOptions)->encode($this->encodeTags);
+        $list = Html::tag('ul', $dropdown->render(), $itemOptions)->encode($this->encodeTags);
+
+        return Li::tag()->content($toggle . $list)->attributes($itemOptions)->encode(false);
     }
 }

--- a/tests/DropdownTest.php
+++ b/tests/DropdownTest.php
@@ -52,7 +52,7 @@ final class DropdownTest extends TestCase
         <ul id="w0-dropdown" class="dropdown-menu" aria-expanded="false">
         <li><a class="dropdown-item disabled" href="#" tabindex="-1" aria-disabled="true">Page1</a></li>
         <li><a class="dropdown-item active" href="#">Page2</a></li>
-        <li><a class="dropdown-item dropdown-toggle" href="#test" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" role="button">Dropdown1</a><ul class="dropdown" aria-expanded="false"><ul id="w1-dropdown" class="dropdown-menu" aria-expanded="false">
+        <li class="dropdown" aria-expanded="false"><a class="dropdown-item dropdown-toggle" href="#test" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" role="button">Dropdown1</a><ul class="dropdown" aria-expanded="false"><ul id="w1-dropdown" class="dropdown-menu" aria-expanded="false">
         <li><h6 class="dropdown-header">Page2</h6></li>
         <li><h6 class="dropdown-header">Page3</h6></li>
         </ul></ul></li>
@@ -96,12 +96,12 @@ final class DropdownTest extends TestCase
             ->render();
         $expected = <<<'HTML'
         <ul id="w0-dropdown" class="dropdown-menu" aria-expanded="false">
-        <li><a class="dropdown-item dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" role="button">Dropdown1</a><ul class="dropdown" aria-expanded="false"><ul id="w1-dropdown" class="submenu-list dropdown-menu" aria-expanded="false">
+        <li class="dropdown" aria-expanded="false"><a class="dropdown-item dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" role="button">Dropdown1</a><ul class="dropdown" aria-expanded="false"><ul id="w1-dropdown" class="submenu-list dropdown-menu" aria-expanded="false">
         <li><h6 class="dropdown-header">Page1</h6></li>
         <li><h6 class="dropdown-header">Page2</h6></li>
         </ul></ul></li>
-        <li><div class="dropdown-divider"></div></li>
-        <li><a class="dropdown-item dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" role="button">Dropdown2</a><ul class="dropdown" aria-expanded="false"><ul id="w2-dropdown" class="submenu-override dropdown-menu" aria-expanded="false">
+        <li><hr class="dropdown-divider"></li>
+        <li class="dropdown" aria-expanded="false"><a class="dropdown-item dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" role="button">Dropdown2</a><ul class="dropdown" aria-expanded="false"><ul id="w2-dropdown" class="submenu-override dropdown-menu" aria-expanded="false">
         <li><h6 class="dropdown-header">Page3</h6></li>
         <li><h6 class="dropdown-header">Page4</h6></li>
         </ul></ul></li>
@@ -162,9 +162,9 @@ final class DropdownTest extends TestCase
         </div>
         <button type="submit" class="btn btn-primary">Sign in</button>
         </form></li>
-        <li><div class="dropdown-divider"></div></li>
+        <li><hr class="dropdown-divider"></li>
         <li><a class="dropdown-item" href="#">New around here? Sign up</a></li>
-        <li><div class="dropdown-divider"></div></li>
+        <li><hr class="dropdown-divider"></li>
         <li><a class="dropdown-item" href="#">Forgot password?</a></li>
         </ul>
         HTML;
@@ -188,7 +188,7 @@ final class DropdownTest extends TestCase
             ->render();
         $expected = <<<'HTML'
         <ul id="w0-dropdown" class="dropdown-menu" aria-expanded="false">
-        <li><a class="dropdown-item dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" role="button">&lt;span&gt;&lt;i class=fas fastest&gt;&lt;/i&gt;Dropdown1&lt;/span&gt;</a><ul class="dropdown" aria-expanded="false"><ul id="w1-dropdown" class="dropdown-menu" aria-expanded="false">
+        <li class="dropdown" aria-expanded="false"><a class="dropdown-item dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" role="button">&lt;span&gt;&lt;i class=fas fastest&gt;&lt;/i&gt;Dropdown1&lt;/span&gt;</a><ul class="dropdown" aria-expanded="false"><ul id="w1-dropdown" class="dropdown-menu" aria-expanded="false">
         <li><h6 class="dropdown-header">Page1</h6></li>
         <li><h6 class="dropdown-header">Page2</h6></li>
         </ul></ul></li>
@@ -210,12 +210,53 @@ final class DropdownTest extends TestCase
             ->render();
         $expected = <<<'HTML'
         <ul id="w2-dropdown" class="dropdown-menu" aria-expanded="false">
-        <li><a class="dropdown-item dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" role="button"><span><i class=fas fastest></i>Dropdown1</span></a><ul class="dropdown" aria-expanded="false"><ul id="w3-dropdown" class="dropdown-menu" aria-expanded="false">
+        <li class="dropdown" aria-expanded="false"><a class="dropdown-item dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" role="button"><span><i class=fas fastest></i>Dropdown1</span></a><ul class="dropdown" aria-expanded="false"><ul id="w3-dropdown" class="dropdown-menu" aria-expanded="false">
         <li><h6 class="dropdown-header">Page1</h6></li>
         <li><h6 class="dropdown-header">Page2</h6></li>
         </ul></ul></li>
         </ul>
         HTML;
+        $this->assertEqualsWithoutLE($expected, $html);
+    }
+
+    public function testMainOptions(): void
+    {
+        Dropdown::counter(0);
+
+        $html = Dropdown::widget()
+            ->withoutEncodeLabels()
+            ->itemOptions([
+                'class' => 'main-item-class',
+            ])
+            ->linkOptions([
+                'class' => 'main-link-class',
+            ])
+            ->items([
+                [
+                    'label' => 'Label 1',
+                    'url' => '#',
+                ],
+                [
+                    'label' => 'Label 2',
+                    'url' => '#',
+                    'options' => [
+                        'id' => 'custom-item-id',
+                        'class' => 'custom-item-class',
+                    ],
+                    'linkOptions' => [
+                        'class' => 'custom-link-class',
+                    ],
+                ],
+            ])
+            ->render();
+
+        $expected = <<<'HTML'
+        <ul id="w0-dropdown" class="dropdown-menu" aria-expanded="false">
+        <li class="main-item-class"><a class="main-link-class dropdown-item" href="#">Label 1</a></li>
+        <li id="custom-item-id" class="custom-item-class"><a class="custom-link-class dropdown-item" href="#">Label 2</a></li>
+        </ul>
+        HTML;
+
         $this->assertEqualsWithoutLE($expected, $html);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Breaks BC?    | ❌ ?

1. Allow `Dropdown::itemOptions()` and `Dropdown::linkOptions()` as in Nav
2. `ItemOptions/options` passed to any list item. Before only with nested menu
3. Allow custom attributes to `dropdown-divider`
4. Allow custom attributes and custom tag to `dropdown-header`