### PR TITLE
Separate nav and tab-content

### DIFF
--- a/tests/TabsTest.php
+++ b/tests/TabsTest.php
@@ -468,7 +468,7 @@ final class TabsTest extends TestCase
             ->navType('nav-lg')
             ->paneOptions([
                 'tag' => 'article',
-                'class' => 'custom-class'
+                'class' => 'custom-class',
             ])->render();
 
         $expected = <<<'HTML'
@@ -486,7 +486,7 @@ final class TabsTest extends TestCase
             ->items([['paneOptions' => ['id' => 'pane1'], 'label' => 'Tab 1', 'content' => '<div>Content 1</div>']])
             ->navType('nav-lg')
             ->linkOptions([
-                'class' => 'custom-link-class'
+                'class' => 'custom-link-class',
             ])->render();
 
         $expected = <<<'HTML'
@@ -517,10 +517,10 @@ final class TabsTest extends TestCase
             ->navType('nav-lg')
             ->navOptions([
                 'linkOptions' => [
-                    'class' => 'custom-link-class'
+                    'class' => 'custom-link-class',
                 ],
                 'itemOptions' => [
-                    'class' => 'custom-item-class'
+                    'class' => 'custom-item-class',
                 ]
             ]);
 

--- a/tests/TabsTest.php
+++ b/tests/TabsTest.php
@@ -361,7 +361,7 @@ final class TabsTest extends TestCase
         $html = Tabs::widget()
             ->items([
                 [
-                    'options' => ['id' => 'pane1'],
+                    'paneOptions' => ['id' => 'pane1'],
                     'label' => 'Tab 1',
                     'content' => '<div>Content 1</div>',
                 ],
@@ -388,7 +388,7 @@ final class TabsTest extends TestCase
             ->items(
                 [
                     [
-                        'options' => ['id' => 'pane1'],
+                        'paneOptions' => ['id' => 'pane1'],
                         'label' => 'Tab 1',
                         'content' => '<div>Content 1</div>',
                     ],
@@ -411,13 +411,13 @@ final class TabsTest extends TestCase
             ->items(
                 [
                     [
-                        'options' => ['id' => 'pane1'],
+                        'paneOptions' => ['id' => 'pane1'],
                         'label' => 'Tab 1',
                         'content' => '<div>Content 1</div>',
                     ],
                 ],
             )
-            ->headerOptions(['class' => 'text-center'])
+            ->itemOptions(['class' => 'text-center'])
             ->render();
         $expected = <<<'HTML'
         <ul id="w0-tabs" class="nav nav-tabs" role="tablist"><li class="text-center nav-item"><a class="nav-link active" href="#pane1" data-bs-toggle="tab" role="tab" aria-controls="pane1" aria-selected="true">Tab 1</a></li></ul>
@@ -449,7 +449,7 @@ final class TabsTest extends TestCase
         Tabs::counter(0);
 
         $html = Tabs::widget()
-            ->items([['options' => ['id' => 'pane1'], 'label' => 'Tab 1', 'content' => '<div>Content 1</div>']])
+            ->items([['paneOptions' => ['id' => 'pane1'], 'label' => 'Tab 1', 'content' => '<div>Content 1</div>']])
             ->navType('nav-lg')
             ->render();
         $expected = <<<'HTML'
@@ -457,5 +457,77 @@ final class TabsTest extends TestCase
         <div class="tab-content"><div id="pane1" class="tab-pane active"><div>Content 1</div></div></div>
         HTML;
         $this->assertEqualsWithoutLE($expected, $html);
+    }
+
+    public function testPaneOptions(): void
+    {
+        Tabs::counter(0);
+
+        $html = Tabs::widget()
+            ->items([['paneOptions' => ['id' => 'pane1'], 'label' => 'Tab 1', 'content' => '<div>Content 1</div>']])
+            ->navType('nav-lg')
+            ->paneOptions([
+                'tag' => 'article',
+                'class' => 'custom-class'
+            ])->render();
+
+        $expected = <<<'HTML'
+        <ul id="w0-tabs" class="nav nav-lg" role="tablist"><li class="nav-item"><a class="nav-link active" href="#pane1" data-bs-toggle="tab" role="tab" aria-controls="pane1" aria-selected="true">Tab 1</a></li></ul>
+        <div class="tab-content"><article id="pane1" class="custom-class tab-pane active"><div>Content 1</div></article></div>
+        HTML;
+        $this->assertEqualsWithoutLE($expected, $html);
+    }
+
+    public function testNavOption(): void
+    {
+        Tabs::counter(0);
+
+        $html = Tabs::widget()
+            ->items([['paneOptions' => ['id' => 'pane1'], 'label' => 'Tab 1', 'content' => '<div>Content 1</div>']])
+            ->navType('nav-lg')
+            ->linkOptions([
+                'class' => 'custom-link-class'
+            ])->render();
+
+        $expected = <<<'HTML'
+        <ul id="w0-tabs" class="nav nav-lg" role="tablist"><li class="nav-item"><a class="custom-link-class nav-link active" href="#pane1" data-bs-toggle="tab" role="tab" aria-controls="pane1" aria-selected="true">Tab 1</a></li></ul>
+        <div class="tab-content"><div id="pane1" class="tab-pane active"><div>Content 1</div></div></div>
+        HTML;
+        $this->assertEqualsWithoutLE($expected, $html);
+
+        Tabs::counter(0);
+
+        $html = Tabs::widget()
+            ->items([['paneOptions' => ['id' => 'pane1'], 'label' => 'Tab 1', 'content' => '<div>Content 1</div>']])
+            ->navType('nav-lg')
+            ->withoutEncodeLabels()->render();
+        $expected = <<<'HTML'
+        <ul id="w0-tabs" class="nav nav-lg" role="tablist"><li class="nav-item"><a class="nav-link active" href="#pane1" data-bs-toggle="tab" role="tab" aria-controls="pane1" aria-selected="true">Tab 1</a></li></ul>
+        <div class="tab-content"><div id="pane1" class="tab-pane active"><div>Content 1</div></div></div>
+        HTML;
+        $this->assertEqualsWithoutLE($expected, $html);
+    }
+
+    public function testNavOptions(): void
+    {
+        Tabs::counter(0);
+
+        $widget = Tabs::widget()
+            ->items([['paneOptions' => ['id' => 'pane1'], 'label' => 'Tab 1', 'content' => '<div>Content 1</div>']])
+            ->navType('nav-lg')
+            ->navOptions([
+                'linkOptions' => [
+                    'class' => 'custom-link-class'
+                ],
+                'itemOptions' => [
+                    'class' => 'custom-item-class'
+                ]
+            ]);
+
+        $expected = <<<'HTML'
+        <ul id="w0-tabs" class="nav nav-lg" role="tablist"><li class="custom-item-class nav-item"><a class="custom-link-class nav-link active" href="#pane1" data-bs-toggle="tab" role="tab" aria-controls="pane1" aria-selected="true">Tab 1</a></li></ul>
+        <div class="tab-content"><div id="pane1" class="tab-pane active"><div>Content 1</div></div></div>
+        HTML;
+        $this->assertEqualsWithoutLE($expected, $widget->render());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️

1. New methods `navOption` and `navOptions` for full customize `Nav::widget()`
2. `itemOptions` passed options to `Nav::widget()` for identity with `Nav::widget()` and `Dropdown::widget()`
3. For customize panes has new method `paneOptions` 
4. each `item::options` passed to  `Nav::widget()`. For customize current pane need `item::paneOptions`