### PR TITLE
Add customization to Tabs and Accordion

### DIFF
--- a/src/Accordion.php
+++ b/src/Accordion.php
@@ -85,22 +85,34 @@ final class Accordion extends Widget
     private bool $encodeLabels = true;
     private bool $encodeTags = false;
     private bool $autoCloseItems = true;
+    private array $headerOptions = [];
     private array $itemToggleOptions = [];
+    private array $contentOptions = [];
     private array $options = [];
     private bool $flush = false;
 
-    protected function run(): string
+    public function getId(?string $suffix = '-accordion'): ?string
     {
-        if (!isset($this->options['id'])) {
-            $this->options['id'] = "{$this->getId()}-accordion";
-        }
+        return $this->options['id'] ?? parent::getId($suffix);
+    }
 
+    public function beforeRun(): bool
+    {
         Html::addCssClass($this->options, ['widget' => 'accordion']);
 
         if ($this->flush) {
             Html::addCssClass($this->options, ['flush' => 'accordion-flush']);
         }
 
+        if (!isset($this->options['id'])) {
+            $this->options['id'] = $this->getId();
+        }
+
+        return parent::beforeRun();
+    }
+
+    protected function run(): string
+    {
         return Html::div($this->renderItems(), $this->options)
             ->encode($this->encodeTags)
             ->render();
@@ -181,6 +193,21 @@ final class Accordion extends Widget
     }
 
     /**
+     * Options for each header if not present in item
+     *
+     * @param array $options
+     *
+     * @return self
+     */
+    public function headerOptions(array $options): self
+    {
+        $new = clone $this;
+        $new->headerOptions = $options;
+
+        return $new;
+    }
+
+    /**
      * The HTML options for the item toggle tag. Key 'tag' might be used here for the tag name specification.
      *
      * For example:
@@ -200,6 +227,21 @@ final class Accordion extends Widget
     {
         $new = clone $this;
         $new->itemToggleOptions = $value;
+
+        return $new;
+    }
+
+    /**
+     * Content options for items if not present in current
+     *
+     * @param array $options
+     *
+     * @return self
+     */
+    public function contentOptions(array $options): self
+    {
+        $new = clone $this;
+        $new->contentOptions = $options;
 
         return $new;
     }
@@ -237,6 +279,30 @@ final class Accordion extends Widget
         return $new;
     }
 
+
+    private function expands(): array
+    {
+        return array_map(static fn ($item) => $item['expand'] ?? null, $this->items);
+    }
+
+    private function hasExpanded(): bool
+    {
+        return in_array(true, $this->expands(), true);
+    }
+
+    private function allClose(): bool
+    {
+        $expands = $this->expands();
+
+        foreach ($expands as $value) {
+            if ($value !== false) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     /**
      * Renders collapsible items as specified on {@see items}.
      *
@@ -248,14 +314,15 @@ final class Accordion extends Widget
     {
         $items = [];
         $index = 0;
-        $expanded = array_search(true, array_column($this->items, 'expand'), true);
+        $expanded = $this->hasExpanded();
+        $allCLose = $this->allClose();
 
         foreach ($this->items as $item) {
             if (!is_array($item)) {
                 $item = ['content' => $item];
             }
 
-            if ($expanded === false && $index === 0) {
+            if ($allCLose === false && $expanded === false && $index === 0) {
                 $item['expand'] = true;
             }
 
@@ -290,19 +357,27 @@ final class Accordion extends Widget
     private function renderItem(string $header, array $item, int $index): string
     {
         if (array_key_exists('content', $item)) {
-            $id = $this->options['id'] . '-collapse' . $index;
             $expand = ArrayHelper::remove($item, 'expand', false);
-            $options = ArrayHelper::getValue($item, 'contentOptions', []);
-            $options['id'] = $id;
+            $options = ArrayHelper::getValue($item, 'contentOptions', $this->contentOptions);
+            $headerOptions = ArrayHelper::remove($item, 'headerOptions', $this->headerOptions);
 
-            Html::addCssClass($options, ['widget' => 'accordion-body collapse']);
+            if (!isset($options['id'])) {
+                $options['id'] = $this->getId() . '-collapse' . $index;
+            }
+
+            if (!isset($headerOptions['id'])) {
+                $headerOptions['id'] = $options['id'] . '-heading';
+            }
+
+            Html::addCssClass($headerOptions, ['widget' => 'accordion-header']);
+            Html::addCssClass($options, ['widget' => 'accordion-collapse collapse']);
 
             if ($expand) {
                 Html::addCssClass($options, ['visibility' => 'show']);
             }
 
             if (!isset($options['aria-label'], $options['aria-labelledby'])) {
-                $options['aria-labelledby'] = $options['id'] . '-heading';
+                $options['aria-labelledby'] = $headerOptions['id'];
             }
 
             $encodeLabel = $item['encode'] ?? $this->encodeLabels;
@@ -318,13 +393,13 @@ final class Accordion extends Widget
                 'data-bs-target' => '#' . $options['id'],
                 'aria-expanded' => $expand ? 'true' : 'false',
                 'aria-controls' => $options['id'],
-            ], $this->itemToggleOptions);
+            ], ArrayHelper::remove($item, 'toggleOptions', $this->itemToggleOptions));
 
             $itemToggleTag = ArrayHelper::remove($itemToggleOptions, 'tag', 'button');
 
             if ($itemToggleTag === 'a') {
                 ArrayHelper::remove($itemToggleOptions, 'data-bs-target');
-                $header = Html::a($header, '#' . $id, $itemToggleOptions)->encode($this->encodeTags) . "\n";
+                $header = Html::a($header, '#' . $options['id'], $itemToggleOptions)->encode($this->encodeTags) . "\n";
             } else {
                 Html::addCssClass($itemToggleOptions, ['widget' => 'accordion-button']);
                 if (!$expand) {
@@ -352,17 +427,14 @@ final class Accordion extends Widget
             throw new RuntimeException('The "content" option is required.');
         }
 
-        $group = [];
-
         if ($this->autoCloseItems) {
-            $options['data-bs-parent'] = '#' . $this->options['id'];
+            $options['data-bs-parent'] = '#' . $this->getId();
         }
 
-        $groupOptions = ['class' => 'accordion-header', 'id' => $options['id'] . '-heading'];
+        $headerTag = ArrayHelper::remove($headerOptions, 'tag', 'h2');
+        $group = Html::tag($headerTag, $header, $headerOptions)->encode($this->encodeTags) . "\n";
+        $group .= Html::div($content, $options)->encode($this->encodeTags);
 
-        $group[] = Html::tag('h2', $header, $groupOptions)->encode($this->encodeTags);
-        $group[] = Html::div($content, $options)->encode($this->encodeTags);
-
-        return implode("\n", $group);
+        return $group;
     }
 }

--- a/src/Tabs.php
+++ b/src/Tabs.php
@@ -69,6 +69,11 @@ final class Tabs extends Widget
     private Nav $nav;
     private array $navOptions = [];
 
+    public function getId(?string $suffix = '-tabs'): ?string
+    {
+        return $this->navOptions['options']['id'] ?? parent::getId('-tabs');
+    }
+
     protected function beforeRun(): bool
     {
         Html::addCssClass($this->tabContentOptions, ['tabContentOptions' => 'tab-content']);
@@ -354,10 +359,7 @@ final class Tabs extends Widget
     private function prepareNavOptions(): array
     {
         $navOptions = $this->navOptions;
-
-        if (!isset($navOptions['options']['id'])) {
-            $navOptions['options']['id'] = "{$this->getId()}-tabs";
-        }
+        $navOptions['options']['id'] = $this->getId();
 
         if (!isset($navOptions['options']['role'])) {
             $navOptions['options']['role'] = 'tablist';
@@ -378,7 +380,7 @@ final class Tabs extends Widget
      *
      * @throws JsonException|RuntimeException
      */
-    private function prepareItems(array &$items, string $navId, string $prefix = ''): void
+    private function prepareItems(array &$items, ?string $navId, string $prefix = ''): void
     {
         if (!$this->hasActiveTab()) {
             $this->activateFirstVisibleTab();

--- a/src/Widget.php
+++ b/src/Widget.php
@@ -14,12 +14,14 @@ abstract class Widget extends \Yiisoft\Widget\Widget
     /**
      * Returns the Id of the widget.
      *
+     * $param string|null $suffix
+     *
      * @return string|null Id of the widget.
      */
-    protected function getId(): ?string
+    public function getId(?string $suffix = null): ?string
     {
         if ($this->autoGenerate && $this->id === null) {
-            $this->id = $this->autoIdPrefix . static::$counter++;
+            $this->id = $this->autoIdPrefix . static::$counter++ . $suffix;
         }
 
         return $this->id;

--- a/tests/AccordionTest.php
+++ b/tests/AccordionTest.php
@@ -75,11 +75,11 @@ final class AccordionTest extends TestCase
             ->render();
         $expected = <<<'HTML'
         <div id="w0-accordion" class="accordion"><div class="accordion-item"><h2 id="w0-accordion-collapse0-heading" class="accordion-header"><button type="button" class="accordion-button" data-bs-toggle="collapse" data-bs-target="#w0-accordion-collapse0" aria-expanded="true" aria-controls="w0-accordion-collapse0">Accordion Item #1</button></h2>
-        <div id="w0-accordion-collapse0" class="accordion-body collapse show" aria-labelledby="w0-accordion-collapse0-heading" data-bs-parent="#w0-accordion"><div class="accordion-body">This is the first items accordion body. It is shown by default, until the collapse plugin the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can  modify any of this with custom CSS or overriding our default variables. Its also worth noting that just about any HTML can go within the .accordion-body, though the transition does limit overflow.</div></div></div>
+        <div id="w0-accordion-collapse0" class="accordion-collapse collapse show" aria-labelledby="w0-accordion-collapse0-heading" data-bs-parent="#w0-accordion"><div class="accordion-body">This is the first items accordion body. It is shown by default, until the collapse plugin the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can  modify any of this with custom CSS or overriding our default variables. Its also worth noting that just about any HTML can go within the .accordion-body, though the transition does limit overflow.</div></div></div>
         <div id="testId" class="testClass accordion-item"><h2 id="w0-accordion-collapse1-heading" class="accordion-header"><button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" data-bs-target="#w0-accordion-collapse1" aria-expanded="false" aria-controls="w0-accordion-collapse1">Accordion Item #2</button></h2>
-        <div id="w0-accordion-collapse1" class="testContentOptions accordion-body collapse" aria-labelledby="w0-accordion-collapse1-heading" data-bs-parent="#w0-accordion"><strong>This is the second items accordion body.</strong> It is hidden by default, until the collapse plugin adds the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can modify any of this with custom CSS or overriding our default variables. Its also worth noting that just about any HTML can go within the <code>.accordion-body</code>, though the transition does limit overflow.</div></div>
+        <div id="w0-accordion-collapse1" class="testContentOptions accordion-collapse collapse" aria-labelledby="w0-accordion-collapse1-heading" data-bs-parent="#w0-accordion"><strong>This is the second items accordion body.</strong> It is hidden by default, until the collapse plugin adds the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can modify any of this with custom CSS or overriding our default variables. Its also worth noting that just about any HTML can go within the <code>.accordion-body</code>, though the transition does limit overflow.</div></div>
         <div id="testId2" class="testClass2 accordion-item"><h2 id="w0-accordion-collapse2-heading" class="accordion-header"><button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" data-bs-target="#w0-accordion-collapse2" aria-expanded="false" aria-controls="w0-accordion-collapse2"><b>Accordion Item #3</b></button></h2>
-        <div id="w0-accordion-collapse2" class="testContentOptions2 accordion-body collapse" aria-labelledby="w0-accordion-collapse2-heading" data-bs-parent="#w0-accordion"><div class="accordion-body"><b>test content1</b></div>
+        <div id="w0-accordion-collapse2" class="testContentOptions2 accordion-collapse collapse" aria-labelledby="w0-accordion-collapse2-heading" data-bs-parent="#w0-accordion"><div class="accordion-body"><b>test content1</b></div>
         <div class="accordion-body"><strong>This is the third items accordion body.</strong> It is hidden by default, until the collapse plugin adds the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can modify any of this with custom CSS or overriding our default variables. Its also worth noting that just about any HTML can go within the <code>.accordion-body</code>, though the transition does limit overflow.</div></div></div></div>
         HTML;
         $this->assertEqualsWithoutLE($expected, $html);
@@ -146,11 +146,11 @@ final class AccordionTest extends TestCase
             ->render();
         $expected = <<<'HTML'
         <div id="w0-accordion" class="accordion accordion-flush"><div class="accordion-item"><h2 id="w0-accordion-collapse0-heading" class="accordion-header"><button type="button" class="accordion-button" data-bs-toggle="collapse" data-bs-target="#w0-accordion-collapse0" aria-expanded="true" aria-controls="w0-accordion-collapse0">Accordion Item #1</button></h2>
-        <div id="w0-accordion-collapse0" class="accordion-body collapse show" aria-labelledby="w0-accordion-collapse0-heading" data-bs-parent="#w0-accordion"><div class="accordion-body">This is the first items accordion body. It is shown by default, until the collapse plugin the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can  modify any of this with custom CSS or overriding our default variables. Its also worth noting that just about any HTML can go within the .accordion-body, though the transition does limit overflow.</div></div></div>
+        <div id="w0-accordion-collapse0" class="accordion-collapse collapse show" aria-labelledby="w0-accordion-collapse0-heading" data-bs-parent="#w0-accordion"><div class="accordion-body">This is the first items accordion body. It is shown by default, until the collapse plugin the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can  modify any of this with custom CSS or overriding our default variables. Its also worth noting that just about any HTML can go within the .accordion-body, though the transition does limit overflow.</div></div></div>
         <div id="testId" class="testClass accordion-item"><h2 id="w0-accordion-collapse1-heading" class="accordion-header"><button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" data-bs-target="#w0-accordion-collapse1" aria-expanded="false" aria-controls="w0-accordion-collapse1">Accordion Item #2</button></h2>
-        <div id="w0-accordion-collapse1" class="testContentOptions accordion-body collapse" aria-labelledby="w0-accordion-collapse1-heading" data-bs-parent="#w0-accordion"><strong>This is the second items accordion body.</strong> It is hidden by default, until the collapse plugin adds the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can modify any of this with custom CSS or overriding our default variables. Its also worth noting that just about any HTML can go within the <code>.accordion-body</code>, though the transition does limit overflow.</div></div>
+        <div id="w0-accordion-collapse1" class="testContentOptions accordion-collapse collapse" aria-labelledby="w0-accordion-collapse1-heading" data-bs-parent="#w0-accordion"><strong>This is the second items accordion body.</strong> It is hidden by default, until the collapse plugin adds the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can modify any of this with custom CSS or overriding our default variables. Its also worth noting that just about any HTML can go within the <code>.accordion-body</code>, though the transition does limit overflow.</div></div>
         <div id="testId2" class="testClass2 accordion-item"><h2 id="w0-accordion-collapse2-heading" class="accordion-header"><button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" data-bs-target="#w0-accordion-collapse2" aria-expanded="false" aria-controls="w0-accordion-collapse2"><b>Accordion Item #3</b></button></h2>
-        <div id="w0-accordion-collapse2" class="testContentOptions2 accordion-body collapse" aria-labelledby="w0-accordion-collapse2-heading" data-bs-parent="#w0-accordion"><div class="accordion-body"><b>test content1</b></div>
+        <div id="w0-accordion-collapse2" class="testContentOptions2 accordion-collapse collapse" aria-labelledby="w0-accordion-collapse2-heading" data-bs-parent="#w0-accordion"><div class="accordion-body"><b>test content1</b></div>
         <div class="accordion-body"><strong>This is the third items accordion body.</strong> It is hidden by default, until the collapse plugin adds the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can modify any of this with custom CSS or overriding our default variables. Its also worth noting that just about any HTML can go within the <code>.accordion-body</code>, though the transition does limit overflow.</div></div></div></div>
         HTML;
         $this->assertEqualsWithoutLE($expected, $html);
@@ -246,9 +246,9 @@ final class AccordionTest extends TestCase
         $html = Accordion::widget()->items($items)->render();
         $expected = <<<'HTML'
         <div id="w0-accordion" class="accordion"><div class="accordion-item"><h2 id="w0-accordion-collapse0-heading" class="accordion-header"><button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" data-bs-target="#w0-accordion-collapse0" aria-expanded="false" aria-controls="w0-accordion-collapse0">Item 1</button></h2>
-        <div id="w0-accordion-collapse0" class="accordion-body collapse" aria-labelledby="w0-accordion-collapse0-heading" data-bs-parent="#w0-accordion">Content 1</div></div>
+        <div id="w0-accordion-collapse0" class="accordion-collapse collapse" aria-labelledby="w0-accordion-collapse0-heading" data-bs-parent="#w0-accordion">Content 1</div></div>
         <div class="accordion-item"><h2 id="w0-accordion-collapse1-heading" class="accordion-header"><button type="button" class="accordion-button" data-bs-toggle="collapse" data-bs-target="#w0-accordion-collapse1" aria-expanded="true" aria-controls="w0-accordion-collapse1">Item 2</button></h2>
-        <div id="w0-accordion-collapse1" class="accordion-body collapse show" aria-labelledby="w0-accordion-collapse1-heading" data-bs-parent="#w0-accordion">Content 2</div></div></div>
+        <div id="w0-accordion-collapse1" class="accordion-collapse collapse show" aria-labelledby="w0-accordion-collapse1-heading" data-bs-parent="#w0-accordion">Content 2</div></div></div>
         HTML;
         $this->assertEqualsWithoutLE($expected, $html);
     }
@@ -317,9 +317,9 @@ final class AccordionTest extends TestCase
         $html = Accordion::widget()->items($items)->options(['class' => 'testMe'])->render();
         $expected = <<<'HTML'
         <div id="w0-accordion" class="testMe accordion"><div class="accordion-item"><h2 id="w0-accordion-collapse0-heading" class="accordion-header"><button type="button" class="accordion-button" data-bs-toggle="collapse" data-bs-target="#w0-accordion-collapse0" aria-expanded="true" aria-controls="w0-accordion-collapse0">Item 1</button></h2>
-        <div id="w0-accordion-collapse0" class="accordion-body collapse show" aria-labelledby="w0-accordion-collapse0-heading" data-bs-parent="#w0-accordion">Content 1</div></div>
+        <div id="w0-accordion-collapse0" class="accordion-collapse collapse show" aria-labelledby="w0-accordion-collapse0-heading" data-bs-parent="#w0-accordion">Content 1</div></div>
         <div class="accordion-item"><h2 id="w0-accordion-collapse1-heading" class="accordion-header"><button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" data-bs-target="#w0-accordion-collapse1" aria-expanded="false" aria-controls="w0-accordion-collapse1">Item 2</button></h2>
-        <div id="w0-accordion-collapse1" class="accordion-body collapse" aria-labelledby="w0-accordion-collapse1-heading" data-bs-parent="#w0-accordion">Content 2</div></div></div>
+        <div id="w0-accordion-collapse1" class="accordion-collapse collapse" aria-labelledby="w0-accordion-collapse1-heading" data-bs-parent="#w0-accordion">Content 2</div></div></div>
         HTML;
         $this->assertEqualsWithoutLE($expected, $html);
     }
@@ -342,18 +342,45 @@ final class AccordionTest extends TestCase
         $html = Accordion::widget()->items($items)->render();
         $expected = <<<'HTML'
         <div id="w0-accordion" class="accordion"><div class="accordion-item"><h2 id="w0-accordion-collapse0-heading" class="accordion-header"><button type="button" class="accordion-button" data-bs-toggle="collapse" data-bs-target="#w0-accordion-collapse0" aria-expanded="true" aria-controls="w0-accordion-collapse0">Item 1</button></h2>
-        <div id="w0-accordion-collapse0" class="accordion-body collapse show" aria-labelledby="w0-accordion-collapse0-heading" data-bs-parent="#w0-accordion">Content 1</div></div>
+        <div id="w0-accordion-collapse0" class="accordion-collapse collapse show" aria-labelledby="w0-accordion-collapse0-heading" data-bs-parent="#w0-accordion">Content 1</div></div>
         <div class="accordion-item"><h2 id="w0-accordion-collapse1-heading" class="accordion-header"><button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" data-bs-target="#w0-accordion-collapse1" aria-expanded="false" aria-controls="w0-accordion-collapse1">&lt;span&gt;&lt;i class="fas fa-eye"&gt;Item 2&lt;/i&gt;&lt;/span&gt;</button></h2>
-        <div id="w0-accordion-collapse1" class="accordion-body collapse" aria-labelledby="w0-accordion-collapse1-heading" data-bs-parent="#w0-accordion">Content 2</div></div></div>
+        <div id="w0-accordion-collapse1" class="accordion-collapse collapse" aria-labelledby="w0-accordion-collapse1-heading" data-bs-parent="#w0-accordion">Content 2</div></div></div>
         HTML;
         $this->assertEqualsWithoutLE($expected, $html);
 
         $html = Accordion::widget()->items($items)->withoutEncodeLabels()->render();
         $expected = <<<'HTML'
         <div id="w1-accordion" class="accordion"><div class="accordion-item"><h2 id="w1-accordion-collapse0-heading" class="accordion-header"><button type="button" class="accordion-button" data-bs-toggle="collapse" data-bs-target="#w1-accordion-collapse0" aria-expanded="true" aria-controls="w1-accordion-collapse0">Item 1</button></h2>
-        <div id="w1-accordion-collapse0" class="accordion-body collapse show" aria-labelledby="w1-accordion-collapse0-heading" data-bs-parent="#w1-accordion">Content 1</div></div>
+        <div id="w1-accordion-collapse0" class="accordion-collapse collapse show" aria-labelledby="w1-accordion-collapse0-heading" data-bs-parent="#w1-accordion">Content 1</div></div>
         <div class="accordion-item"><h2 id="w1-accordion-collapse1-heading" class="accordion-header"><button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" data-bs-target="#w1-accordion-collapse1" aria-expanded="false" aria-controls="w1-accordion-collapse1"><span><i class="fas fa-eye">Item 2</i></span></button></h2>
-        <div id="w1-accordion-collapse1" class="accordion-body collapse" aria-labelledby="w1-accordion-collapse1-heading" data-bs-parent="#w1-accordion">Content 2</div></div></div>
+        <div id="w1-accordion-collapse1" class="accordion-collapse collapse" aria-labelledby="w1-accordion-collapse1-heading" data-bs-parent="#w1-accordion">Content 2</div></div></div>
+        HTML;
+        $this->assertEqualsWithoutLE($expected, $html);
+    }
+
+    public function testAllClose(): void
+    {
+        Accordion::counter(0);
+
+        $items = [
+            [
+                'label' => 'Item 1',
+                'content' => 'Content 1',
+                'expand' => false,
+            ],
+            [
+                'label' => 'Item 2',
+                'content' => 'Content 2',
+                'expand' => false,
+            ],
+        ];
+
+        $html = Accordion::widget()->items($items)->render();
+        $expected = <<<'HTML'
+        <div id="w0-accordion" class="accordion"><div class="accordion-item"><h2 id="w0-accordion-collapse0-heading" class="accordion-header"><button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" data-bs-target="#w0-accordion-collapse0" aria-expanded="false" aria-controls="w0-accordion-collapse0">Item 1</button></h2>
+        <div id="w0-accordion-collapse0" class="accordion-collapse collapse" aria-labelledby="w0-accordion-collapse0-heading" data-bs-parent="#w0-accordion">Content 1</div></div>
+        <div class="accordion-item"><h2 id="w0-accordion-collapse1-heading" class="accordion-header"><button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" data-bs-target="#w0-accordion-collapse1" aria-expanded="false" aria-controls="w0-accordion-collapse1">Item 2</button></h2>
+        <div id="w0-accordion-collapse1" class="accordion-collapse collapse" aria-labelledby="w0-accordion-collapse1-heading" data-bs-parent="#w0-accordion">Content 2</div></div></div>
         HTML;
         $this->assertEqualsWithoutLE($expected, $html);
     }

--- a/tests/TabsTest.php
+++ b/tests/TabsTest.php
@@ -468,7 +468,7 @@ final class TabsTest extends TestCase
             ->navType('nav-lg')
             ->paneOptions([
                 'tag' => 'article',
-                'class' => 'custom-class'
+                'class' => 'custom-class',
             ])->render();
 
         $expected = <<<'HTML'
@@ -486,7 +486,7 @@ final class TabsTest extends TestCase
             ->items([['paneOptions' => ['id' => 'pane1'], 'label' => 'Tab 1', 'content' => '<div>Content 1</div>']])
             ->navType('nav-lg')
             ->linkOptions([
-                'class' => 'custom-link-class'
+                'class' => 'custom-link-class',
             ])->render();
 
         $expected = <<<'HTML'
@@ -517,10 +517,10 @@ final class TabsTest extends TestCase
             ->navType('nav-lg')
             ->navOptions([
                 'linkOptions' => [
-                    'class' => 'custom-link-class'
+                    'class' => 'custom-link-class',
                 ],
                 'itemOptions' => [
-                    'class' => 'custom-item-class'
+                    'class' => 'custom-item-class',
                 ]
             ]);
 

--- a/tests/TabsTest.php
+++ b/tests/TabsTest.php
@@ -521,7 +521,7 @@ final class TabsTest extends TestCase
                 ],
                 'itemOptions' => [
                     'class' => 'custom-item-class',
-                ]
+                ],
             ]);
 
         $expected = <<<'HTML'

--- a/tests/TabsTest.php
+++ b/tests/TabsTest.php
@@ -361,7 +361,7 @@ final class TabsTest extends TestCase
         $html = Tabs::widget()
             ->items([
                 [
-                    'options' => ['id' => 'pane1'],
+                    'paneOptions' => ['id' => 'pane1'],
                     'label' => 'Tab 1',
                     'content' => '<div>Content 1</div>',
                 ],
@@ -388,7 +388,7 @@ final class TabsTest extends TestCase
             ->items(
                 [
                     [
-                        'options' => ['id' => 'pane1'],
+                        'paneOptions' => ['id' => 'pane1'],
                         'label' => 'Tab 1',
                         'content' => '<div>Content 1</div>',
                     ],
@@ -411,13 +411,13 @@ final class TabsTest extends TestCase
             ->items(
                 [
                     [
-                        'options' => ['id' => 'pane1'],
+                        'paneOptions' => ['id' => 'pane1'],
                         'label' => 'Tab 1',
                         'content' => '<div>Content 1</div>',
                     ],
                 ],
             )
-            ->headerOptions(['class' => 'text-center'])
+            ->itemOptions(['class' => 'text-center'])
             ->render();
         $expected = <<<'HTML'
         <ul id="w0-tabs" class="nav nav-tabs" role="tablist"><li class="text-center nav-item"><a class="nav-link active" href="#pane1" data-bs-toggle="tab" role="tab" aria-controls="pane1" aria-selected="true">Tab 1</a></li></ul>
@@ -449,7 +449,7 @@ final class TabsTest extends TestCase
         Tabs::counter(0);
 
         $html = Tabs::widget()
-            ->items([['options' => ['id' => 'pane1'], 'label' => 'Tab 1', 'content' => '<div>Content 1</div>']])
+            ->items([['paneOptions' => ['id' => 'pane1'], 'label' => 'Tab 1', 'content' => '<div>Content 1</div>']])
             ->navType('nav-lg')
             ->render();
         $expected = <<<'HTML'
@@ -457,5 +457,77 @@ final class TabsTest extends TestCase
         <div class="tab-content"><div id="pane1" class="tab-pane active"><div>Content 1</div></div></div>
         HTML;
         $this->assertEqualsWithoutLE($expected, $html);
+    }
+
+    public function testPaneOptions(): void
+    {
+        Tabs::counter(0);
+
+        $html = Tabs::widget()
+            ->items([['paneOptions' => ['id' => 'pane1'], 'label' => 'Tab 1', 'content' => '<div>Content 1</div>']])
+            ->navType('nav-lg')
+            ->paneOptions([
+                'tag' => 'article',
+                'class' => 'custom-class'
+            ])->render();
+
+        $expected = <<<'HTML'
+        <ul id="w0-tabs" class="nav nav-lg" role="tablist"><li class="nav-item"><a class="nav-link active" href="#pane1" data-bs-toggle="tab" role="tab" aria-controls="pane1" aria-selected="true">Tab 1</a></li></ul>
+        <div class="tab-content"><article id="pane1" class="custom-class tab-pane active"><div>Content 1</div></article></div>
+        HTML;
+        $this->assertEqualsWithoutLE($expected, $html);
+    }
+
+    public function testNavOption(): void
+    {
+        Tabs::counter(0);
+
+        $html = Tabs::widget()
+            ->items([['paneOptions' => ['id' => 'pane1'], 'label' => 'Tab 1', 'content' => '<div>Content 1</div>']])
+            ->navType('nav-lg')
+            ->linkOptions([
+                'class' => 'custom-link-class'
+            ])->render();
+
+        $expected = <<<'HTML'
+        <ul id="w0-tabs" class="nav nav-lg" role="tablist"><li class="nav-item"><a class="custom-link-class nav-link active" href="#pane1" data-bs-toggle="tab" role="tab" aria-controls="pane1" aria-selected="true">Tab 1</a></li></ul>
+        <div class="tab-content"><div id="pane1" class="tab-pane active"><div>Content 1</div></div></div>
+        HTML;
+        $this->assertEqualsWithoutLE($expected, $html);
+
+        Tabs::counter(0);
+
+        $html = Tabs::widget()
+            ->items([['paneOptions' => ['id' => 'pane1'], 'label' => 'Tab 1', 'content' => '<div>Content 1</div>']])
+            ->navType('nav-lg')
+            ->withoutEncodeLabels()->render();
+        $expected = <<<'HTML'
+        <ul id="w0-tabs" class="nav nav-lg" role="tablist"><li class="nav-item"><a class="nav-link active" href="#pane1" data-bs-toggle="tab" role="tab" aria-controls="pane1" aria-selected="true">Tab 1</a></li></ul>
+        <div class="tab-content"><div id="pane1" class="tab-pane active"><div>Content 1</div></div></div>
+        HTML;
+        $this->assertEqualsWithoutLE($expected, $html);
+    }
+
+    public function testNavOptions(): void
+    {
+        Tabs::counter(0);
+
+        $widget = Tabs::widget()
+            ->items([['paneOptions' => ['id' => 'pane1'], 'label' => 'Tab 1', 'content' => '<div>Content 1</div>']])
+            ->navType('nav-lg')
+            ->navOptions([
+                'linkOptions' => [
+                    'class' => 'custom-link-class'
+                ],
+                'itemOptions' => [
+                    'class' => 'custom-item-class'
+                ]
+            ]);
+
+        $expected = <<<'HTML'
+        <ul id="w0-tabs" class="nav nav-lg" role="tablist"><li class="custom-item-class nav-item"><a class="custom-link-class nav-link active" href="#pane1" data-bs-toggle="tab" role="tab" aria-controls="pane1" aria-selected="true">Tab 1</a></li></ul>
+        <div class="tab-content"><div id="pane1" class="tab-pane active"><div>Content 1</div></div></div>
+        HTML;
+        $this->assertEqualsWithoutLE($expected, $widget->render());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️

### Main
1. Change access `getId()` to public - that allow send it to some js/vue/jquery etc application
2. `getId()` has suffix argument instead of `$this->getId() . '-some-suffix'`

### Tabs
1. New methods `navOption` and `navOptions` for full customize `Nav::widget()`
2. `itemOptions` passed options to `Nav::widget()` for identity with `Nav::widget()` and `Dropdown::widget()`
3. For customize panes has new method `paneOptions` 
4. each `item::options` passed to  `Nav::widget()`. For customize current pane need `item::paneOptions`

### Accordion
1. Allow no one expanded item if set to all `item['expand'] = false`
2. Allow header custom class and custom tag - may solve SEO problem with **h*** tags
3. Allow header options and toggle options for each item - maybe used for highlight some headers or something else
