### PR TITLE
NavBar/Modal refactoring + Offcanvas widget

### DIFF
--- a/src/Alert.php
+++ b/src/Alert.php
@@ -27,15 +27,6 @@ use function array_merge;
  */
 final class Alert extends Widget
 {
-    private const TYPE_PRIMARY = 'alert-primary';
-    private const TYPE_SECONDARY = 'alert-secondary';
-    private const TYPE_SUCCESS = 'alert-success';
-    private const TYPE_DANGER = 'alert-danger';
-    private const TYPE_WARNING = 'alert-warning';
-    private const TYPE_INFO = 'alert-info';
-    private const TYPE_LIGHT = 'alert-light';
-    private const TYPE_DARK = 'alert-dark';
-
     private string $body = '';
     private ?string $header = null;
     private array $headerOptions = [];
@@ -43,7 +34,7 @@ final class Alert extends Widget
     private ?array $closeButton = [
         'class' => 'btn-close',
     ];
-    private string $buttonTag = 'button';
+    private string $closeButtonTag = 'button';
     private bool $encode = false;
     private array $options = [];
     private array $classNames = [];
@@ -58,11 +49,16 @@ final class Alert extends Widget
     {
         $options = $this->prepareOptions();
         $tag = ArrayHelper::remove($options, 'tag', 'div');
+        $closeButtonOutside = $this->closeButton['outside'] ?? false;
 
         $content = Html::openTag($tag, $options);
         $content .= $this->renderHeader();
         $content .= $this->encode ? Html::encode($this->body) : $this->body;
-        $content .= $this->renderCloseButton(false);
+
+        if (!$closeButtonOutside) {
+            $content .= $this->renderCloseButton(false);
+        }
+
         $content .= Html::closeTag($tag);
 
         return $content;
@@ -179,10 +175,10 @@ final class Alert extends Widget
      *
      * @return self
      */
-    public function buttonTag(string $tag): self
+    public function closeButtonTag(string $tag): self
     {
         $new = clone $this;
-        $new->buttonTag = $tag;
+        $new->closeButtonTag = $tag;
 
         return $new;
     }
@@ -256,7 +252,7 @@ final class Alert extends Widget
      */
     public function primary(): self
     {
-        return $this->addClassNames(self::TYPE_PRIMARY);
+        return $this->addClassNames('alert-primary');
     }
 
     /**
@@ -266,7 +262,7 @@ final class Alert extends Widget
      */
     public function secondary(): self
     {
-        return $this->addClassNames(self::TYPE_SECONDARY);
+        return $this->addClassNames('alert-secondary');
     }
 
     /**
@@ -276,7 +272,7 @@ final class Alert extends Widget
      */
     public function success(): self
     {
-        return $this->addClassNames(self::TYPE_SUCCESS);
+        return $this->addClassNames('alert-success');
     }
 
     /**
@@ -286,7 +282,7 @@ final class Alert extends Widget
      */
     public function danger(): self
     {
-        return $this->addClassNames(self::TYPE_DANGER);
+        return $this->addClassNames('alert-danger');
     }
 
     /**
@@ -296,7 +292,7 @@ final class Alert extends Widget
      */
     public function warning(): self
     {
-        return $this->addClassNames(self::TYPE_WARNING);
+        return $this->addClassNames('alert-warning');
     }
 
     /**
@@ -306,7 +302,7 @@ final class Alert extends Widget
      */
     public function info(): self
     {
-        return $this->addClassNames(self::TYPE_INFO);
+        return $this->addClassNames('alert-info');
     }
 
     /**
@@ -316,7 +312,7 @@ final class Alert extends Widget
      */
     public function light(): self
     {
-        return $this->addClassNames(self::TYPE_LIGHT);
+        return $this->addClassNames('alert-light');
     }
 
     /**
@@ -326,7 +322,7 @@ final class Alert extends Widget
      */
     public function dark(): self
     {
-        return $this->addClassNames(self::TYPE_DARK);
+        return $this->addClassNames('alert-dark');
     }
 
     /**
@@ -352,7 +348,9 @@ final class Alert extends Widget
         $label = ArrayHelper::remove($options, 'label', '');
         $encode = ArrayHelper::remove($options, 'encode', $this->encode);
 
-        if ($this->buttonTag === 'button' && !isset($options['type'])) {
+        unset($options['outside']);
+
+        if ($this->closeButtonTag === 'button' && !isset($options['type'])) {
             $options['type'] = 'button';
         }
 
@@ -360,7 +358,7 @@ final class Alert extends Widget
             $options['data-bs-target'] = '#' . $this->getId();
         }
 
-        return Html::tag($this->buttonTag, $label, $options)->encode($encode)->render();
+        return Html::tag($this->closeButtonTag, $label, $options)->encode($encode)->render();
     }
 
     /**
@@ -393,7 +391,7 @@ final class Alert extends Widget
     {
         $options = $this->options;
         $options['id'] = $this->getId();
-        $classNames = array_merge(['widget' => 'alert'], $this->classNames);
+        $classNames = array_merge(['alert'], $this->classNames);
 
         if ($this->closeButton !== null) {
             $classNames[] = 'alert-dismissible';

--- a/src/Alert.php
+++ b/src/Alert.php
@@ -46,7 +46,7 @@ final class Alert extends Widget
     private string $buttonTag = 'button';
     private bool $encode = false;
     private array $options = [];
-    private ?string $type = null;
+    private array $classNames = [];
     private bool $fade = false;
 
     public function getId(?string $suffix = '-alert'): ?string
@@ -241,10 +241,10 @@ final class Alert extends Widget
      *
      * @return self
      */
-    public function type(string $type): self
+    public function addClassNames(string ...$classNames): self
     {
         $new = clone $this;
-        $new->type = $type;
+        $new->classNames = array_filter($classNames, static fn ($name) => $name !== '');
 
         return $new;
     }
@@ -256,7 +256,7 @@ final class Alert extends Widget
      */
     public function primary(): self
     {
-        return $this->type(self::TYPE_PRIMARY);
+        return $this->addClassNames(self::TYPE_PRIMARY);
     }
 
     /**
@@ -266,7 +266,7 @@ final class Alert extends Widget
      */
     public function secondary(): self
     {
-        return $this->type(self::TYPE_SECONDARY);
+        return $this->addClassNames(self::TYPE_SECONDARY);
     }
 
     /**
@@ -276,7 +276,7 @@ final class Alert extends Widget
      */
     public function success(): self
     {
-        return $this->type(self::TYPE_SUCCESS);
+        return $this->addClassNames(self::TYPE_SUCCESS);
     }
 
     /**
@@ -286,7 +286,7 @@ final class Alert extends Widget
      */
     public function danger(): self
     {
-        return $this->type(self::TYPE_DANGER);
+        return $this->addClassNames(self::TYPE_DANGER);
     }
 
     /**
@@ -296,7 +296,7 @@ final class Alert extends Widget
      */
     public function warning(): self
     {
-        return $this->type(self::TYPE_WARNING);
+        return $this->addClassNames(self::TYPE_WARNING);
     }
 
     /**
@@ -306,7 +306,7 @@ final class Alert extends Widget
      */
     public function info(): self
     {
-        return $this->type(self::TYPE_INFO);
+        return $this->addClassNames(self::TYPE_INFO);
     }
 
     /**
@@ -316,7 +316,7 @@ final class Alert extends Widget
      */
     public function light(): self
     {
-        return $this->type(self::TYPE_LIGHT);
+        return $this->addClassNames(self::TYPE_LIGHT);
     }
 
     /**
@@ -326,7 +326,7 @@ final class Alert extends Widget
      */
     public function dark(): self
     {
-        return $this->type(self::TYPE_DARK);
+        return $this->addClassNames(self::TYPE_DARK);
     }
 
     /**
@@ -393,11 +393,7 @@ final class Alert extends Widget
     {
         $options = $this->options;
         $options['id'] = $this->getId();
-        $classNames = ['widget' => 'alert'];
-
-        if ($this->type) {
-            $classNames[] = $this->type;
-        }
+        $classNames = array_merge(['widget' => 'alert'], $this->classNames);
 
         if ($this->closeButton !== null) {
             $classNames[] = 'alert-dismissible';

--- a/src/Alert.php
+++ b/src/Alert.php
@@ -60,7 +60,7 @@ final class Alert extends Widget
         $content = Html::openTag($tag, $options);
         $content .= $this->renderHeader();
         $content .= $this->encode ? Html::encode($this->body) : $this->body;
-        $content .= $this->renderCloseButton();
+        $content .= $this->renderCloseButton(false);
         $content .= Html::closeTag($tag);
 
         return $content;
@@ -301,7 +301,7 @@ final class Alert extends Widget
      *
      * @return string the rendering result
      */
-    public function renderCloseButton(bool $outside = false): ?string
+    public function renderCloseButton(bool $outside = true): ?string
     {
         if ($this->closeButton === null) {
             return null;

--- a/src/Alert.php
+++ b/src/Alert.php
@@ -27,21 +27,23 @@ use function array_merge;
  */
 final class Alert extends Widget
 {
-    public const TYPE_PRIMARY = 'alert-primary';
-    public const TYPE_SECONDARY = 'alert-secondary';
-    public const TYPE_SUCCESS = 'alert-success';
-    public const TYPE_DANGER = 'alert-danger';
-    public const TYPE_WARNING = 'alert-warning';
-    public const TYPE_INFO = 'alert-info';
-    public const TYPE_LIGHT = 'alert-light';
-    public const TYPE_DARK = 'alert-dark';
+    private const TYPE_PRIMARY = 'alert-primary';
+    private const TYPE_SECONDARY = 'alert-secondary';
+    private const TYPE_SUCCESS = 'alert-success';
+    private const TYPE_DANGER = 'alert-danger';
+    private const TYPE_WARNING = 'alert-warning';
+    private const TYPE_INFO = 'alert-info';
+    private const TYPE_LIGHT = 'alert-light';
+    private const TYPE_DARK = 'alert-dark';
 
     private string $body = '';
     private ?string $header = null;
     private array $headerOptions = [];
+    private string $headerTag = 'h4';
     private ?array $closeButton = [
         'class' => 'btn-close',
     ];
+    private string $buttonTag = 'button';
     private bool $encode = false;
     private array $options = [];
     private ?string $type = null;
@@ -115,6 +117,21 @@ final class Alert extends Widget
     }
 
     /**
+     * Set tag name for header
+     *
+     * @param string $tag
+     *
+     * @return self
+     */
+    public function headerTag(string $tag): self
+    {
+        $new = clone $this;
+        $new->headerTag = $tag;
+
+        return $new;
+    }
+
+    /**
      * The options for rendering the close button tag.
      *
      * The close button is displayed in the header of the modal window. Clicking on the button will hide the modal
@@ -134,7 +151,7 @@ final class Alert extends Widget
      *
      * @return self
      */
-    public function closeButton(?array $value): self
+    public function closeButton(array $value): self
     {
         $new = clone $this;
         $new->closeButton = $value;
@@ -149,7 +166,25 @@ final class Alert extends Widget
      */
     public function withoutCloseButton(): self
     {
-        return $this->closeButton(null);
+        $new = clone $this;
+        $new->closeButton = null;
+
+        return $new;
+    }
+
+    /**
+     * Set close button tag
+     *
+     * @param string $tag
+     *
+     * @return self
+     */
+    public function buttonTag(string $tag): self
+    {
+        $new = clone $this;
+        $new->buttonTag = $tag;
+
+        return $new;
     }
 
     /**
@@ -200,7 +235,7 @@ final class Alert extends Widget
     }
 
     /**
-     * Set type of alert, 'alert-success', 'alert-danger' etc
+     * Set type of alert, 'alert-success', 'alert-danger', 'custom-alert' etc
      *
      * @param string $type
      *
@@ -314,11 +349,10 @@ final class Alert extends Widget
                 'data-bs-dismiss' => 'alert',
             ],
         );
-        $tag = ArrayHelper::remove($options, 'tag', 'button');
         $label = ArrayHelper::remove($options, 'label', '');
         $encode = ArrayHelper::remove($options, 'encode', $this->encode);
 
-        if ($tag === 'button' && !isset($options['type'])) {
+        if ($this->buttonTag === 'button' && !isset($options['type'])) {
             $options['type'] = 'button';
         }
 
@@ -326,7 +360,7 @@ final class Alert extends Widget
             $options['data-bs-target'] = '#' . $this->getId();
         }
 
-        return Html::tag($tag, $label, $options)->encode($encode)->render();
+        return Html::tag($this->buttonTag, $label, $options)->encode($encode)->render();
     }
 
     /**
@@ -341,12 +375,11 @@ final class Alert extends Widget
         }
 
         $options = $this->headerOptions;
-        $tag = ArrayHelper::remove($options, 'tag', 'h4');
         $encode = ArrayHelper::remove($options, 'encode', true);
 
         Html::addCssClass($options, ['alert-heading']);
 
-        return Html::tag($tag, $this->header, $options)->encode($encode)->render();
+        return Html::tag($this->headerTag, $this->header, $options)->encode($encode)->render();
     }
 
     /**

--- a/src/Modal.php
+++ b/src/Modal.php
@@ -84,13 +84,14 @@ final class Modal extends Widget
         $dialogOptions = $this->prepareDialogOptions();
         $contentOptions = $this->contentOptions;
         $contentTag = ArrayHelper::remove($contentOptions, 'tag', 'div');
+        $dialogTag = ArrayHelper::remove($dialogOptions, 'tag', 'div');
 
         Html::addCssClass($contentOptions, ['modal-content']);
 
         return
             $this->renderToggleButton() .
             Html::openTag('div', $options) .
-            Html::openTag('div', $dialogOptions) .
+            Html::openTag($dialogTag, $dialogOptions) .
             Html::openTag($contentTag, $contentOptions) .
             $this->renderHeader() .
             $this->renderBodyBegin();
@@ -99,12 +100,13 @@ final class Modal extends Widget
     protected function run(): string
     {
         $contentTag = ArrayHelper::getValue($this->contentOptions, 'tag', 'div');
+        $dialogTag = ArrayHelper::getValue($this->dialogOptions, 'tag', 'div');
 
         return
             $this->renderBodyEnd() .
             $this->renderFooter() .
             Html::closeTag($contentTag) . // modal-content
-            Html::closeTag('div') . // modal-dialog
+            Html::closeTag($dialogTag) . // modal-dialog
             Html::closeTag('div');
     }
 

--- a/src/Modal.php
+++ b/src/Modal.php
@@ -18,7 +18,7 @@ use function array_merge;
  *
  * ```php
  * Modal::widget()
- *     ->title('<h2>Hello world</h2>')
+ *     ->title('Hello world')
  *     ->toggleButton(['label' => 'click me'])
  *     ->begin();
  *
@@ -30,65 +30,176 @@ use function array_merge;
 final class Modal extends Widget
 {
     /**
-     * The additional css class of large modal
-     */
-    public const SIZE_LARGE = 'modal-lg';
-
-    /**
-     * The additional css class of small modal
+     * Size classes
      */
     public const SIZE_SMALL = 'modal-sm';
+    public const SIZE_DEFAULT = null;
+    public const SIZE_LARGE = 'modal-lg';
+    public const SIZE_EXTRA_LARGE = 'modal-xl';
 
     /**
-     * The additional css class of default modal
+     * Fullsceen classes
      */
-    public const SIZE_DEFAULT = '';
+    public const FULLSCREEN_ALWAYS = 'modal-fullscreen';
+    public const FULLSCREEN_BELOW_SM = 'modal-fullscreen-sm-down';
+    public const FULLSCREEN_BELOW_MD = 'modal-fullscreen-md-down';
+    public const FULLSCREEN_BELOW_LG = 'modal-fullscreen-lg-down';
+    public const FULLSCREEN_BELOW_XL = 'modal-fullscreen-xl-down';
+    public const FULLSCREEN_BELOW_XXL = 'modal-fullscreen-xxl-down';
 
-    private string $title = '';
+    private ?string $title = null;
     private array $titleOptions = [];
     private array $headerOptions = [];
+    private array $dialogOptions = [];
+    private array $contentOptions = [];
     private array $bodyOptions = [];
-    private string $footer = '';
+    private ?string $footer = null;
     private array $footerOptions = [];
-    private string $size = '';
-    private array $closeButton = [];
-    private bool $closeButtonEnabled = true;
-    private array $toggleButton = [];
-    private bool $toggleButtonEnabled = true;
+    private ?string $size = self::SIZE_DEFAULT;
+    private ?array $closeButton = ['class' => 'btn-close'];
+    private ?array $toggleButton = [];
     private array $options = [];
     private bool $encodeTags = false;
+    private bool $fade = true;
+    private bool $staticBackdrop = false;
+    private bool $scrollable = false;
+    private bool $centered = false;
+    private ?string $fullscreen = null;
+
+    public function getId(?string $suffix = '-modal'): ?string
+    {
+        return $this->options['id'] ?? parent::getId($suffix);
+    }
+
+    public function getTitleId(): string
+    {
+        return $this->titleOptions['id'] ?? $this->getId() . '-label';
+    }
 
     public function begin(): string
     {
         parent::begin();
 
-        if (!isset($this->options['id'])) {
-            $this->options['id'] = "{$this->getId()}-modal";
-        }
+        $options = $this->prepareOptions();
+        $dialogOptions = $this->prepareDialogOptions();
+        $contentOptions = $this->contentOptions;
+        $contentTag = ArrayHelper::remove($contentOptions, 'tag', 'div');
 
-        if ($this->encodeTags === false) {
-            $this->options['encode'] = false;
-        }
-
-        $this->initOptions();
+        Html::addCssClass($contentOptions, ['modal-content']);
 
         return
-            $this->renderToggleButton() . "\n" .
-            Html::openTag('div', $this->options) . "\n" .
-            Html::openTag('div', ['class' => 'modal-dialog ' . $this->size]) . "\n" .
-            Html::openTag('div', ['class' => 'modal-content']) . "\n" .
-            $this->renderHeader() . "\n" .
-            $this->renderBodyBegin() . "\n";
+            $this->renderToggleButton() .
+            Html::openTag('div', $options) .
+            Html::openTag('div', $dialogOptions) .
+            Html::openTag($contentTag, $contentOptions) .
+            $this->renderHeader() .
+            $this->renderBodyBegin();
     }
 
     protected function run(): string
     {
+        $contentTag = ArrayHelper::getValue($this->contentOptions, 'tag', 'div');
+
         return
-            "\n" . $this->renderBodyEnd() .
-            "\n" . $this->renderFooter() .
-            "\n" . Html::closeTag('div') . // modal-content
-            "\n" . Html::closeTag('div') . // modal-dialog
-            "\n" . Html::closeTag('div');
+            $this->renderBodyEnd() .
+            $this->renderFooter() .
+            Html::closeTag($contentTag) . // modal-content
+            Html::closeTag('div') . // modal-dialog
+            Html::closeTag('div');
+    }
+
+    /**
+     * Prepare options for modal layer
+     *
+     * @return array
+     */
+    private function prepareOptions(): array
+    {
+        $options = array_merge([
+            'role' => 'dialog',
+            'tabindex' => -1,
+            'aria-hidden' => 'true',
+        ], $this->options);
+
+        $options['id'] = $this->getId();
+
+        /** @psalm-suppress InvalidArgument */
+        Html::addCssClass($options, ['widget' => 'modal']);
+
+        if ($this->fade) {
+            Html::addCssClass($options, ['animation' => 'fade']);
+        }
+
+        if (!isset($options['aria-label'], $options['aria-labelledby']) && !empty($this->title)) {
+            $options['aria-labelledby'] = $this->getTitleId();
+        }
+
+        if ($this->staticBackdrop) {
+            $options['data-bs-backdrop'] = 'static';
+        }
+
+        return $options;
+    }
+
+    /**
+     * Prepare options for dialog layer
+     *
+     * @return array
+     */
+    private function prepareDialogOptions(): array
+    {
+        $options = $this->dialogOptions;
+        $classNames = ['modal-dialog'];
+
+        if ($this->size) {
+            $classNames[] = $this->size;
+        }
+
+        if ($this->fullscreen) {
+            $classNames[] = $this->fullscreen;
+        }
+
+        if ($this->scrollable) {
+            $classNames[] = 'modal-dialog-scrollable';
+        }
+
+        if ($this->centered) {
+            $classNames[] = 'modal-dialog-centered';
+        }
+
+        Html::addCssClass($options, $classNames);
+
+        return $options;
+    }
+
+    /**
+     * Dialog layer options
+     *
+     * @param array $options
+     *
+     * @return self
+     */
+    public function dialogOptions(array $options): self
+    {
+        $new = clone $this;
+        $new->dialogOptions = $options;
+
+        return $new;
+    }
+
+    /**
+     * Set options for content layer
+     *
+     * @param array $options
+     *
+     * @return self
+     */
+    public function contentOptions(array $options): self
+    {
+        $new = clone $this;
+        $new->contentOptions = $options;
+
+        return $new;
     }
 
     /**
@@ -126,7 +237,7 @@ final class Modal extends Widget
      *
      * @return self
      */
-    public function closeButton(array $value): self
+    public function closeButton(?array $value): self
     {
         $new = clone $this;
         $new->closeButton = $value;
@@ -141,10 +252,7 @@ final class Modal extends Widget
      */
     public function withoutCloseButton(): self
     {
-        $new = clone $this;
-        $new->closeButtonEnabled = false;
-
-        return $new;
+        return $this->closeButton(null);
     }
 
     /**
@@ -154,7 +262,7 @@ final class Modal extends Widget
      *
      * @return self
      */
-    public function footer(string $value): self
+    public function footer(?string $value): self
     {
         $new = clone $this;
         $new->footer = $value;
@@ -219,7 +327,7 @@ final class Modal extends Widget
      *
      * @return self
      */
-    public function title(string $value): self
+    public function title(?string $value): self
     {
         $new = clone $this;
         $new->title = $value;
@@ -262,7 +370,7 @@ final class Modal extends Widget
      *
      * @return self
      */
-    public function toggleButton(array $value): self
+    public function toggleButton(?array $value): self
     {
         $new = clone $this;
         $new->toggleButton = $value;
@@ -277,10 +385,7 @@ final class Modal extends Widget
      */
     public function withoutToggleButton(): self
     {
-        $new = clone $this;
-        $new->toggleButtonEnabled = false;
-
-        return $new;
+        return $this->toggleButton(null);
     }
 
     /**
@@ -289,11 +394,110 @@ final class Modal extends Widget
      * @param string $value
      *
      * @return self
+     *
+     * @link https://getbootstrap.com/docs/5.1/components/modal/#optional-sizes
      */
-    public function size(string $value): self
+    public function size(?string $value): self
     {
         $new = clone $this;
         $new->size = $value;
+
+        return $new;
+    }
+
+    /**
+     * Enable/disable static backdrop
+     *
+     * @param bool $value
+     *
+     * @return self
+     *
+     * @link https://getbootstrap.com/docs/5.1/components/modal/#static-backdrop
+     */
+    public function staticBackdrop(bool $value = true): self
+    {
+        if ($value === $this->staticBackdrop) {
+            return $this;
+        }
+
+        $new = clone $this;
+        $new->staticBackdrop = $value;
+
+        return $new;
+    }
+
+    /**
+     * Enable/Disable scrolling long content
+     *
+     * @param bool $scrollable
+     *
+     * @return self
+     *
+     * @link https://getbootstrap.com/docs/5.1/components/modal/#scrolling-long-content
+     */
+    public function scrollable(bool $scrollable = true): self
+    {
+        if ($scrollable === $this->scrollable) {
+            return $this;
+        }
+
+        $new = clone $this;
+        $new->scrollable = $scrollable;
+
+        return $new;
+    }
+
+    /**
+     * Enable/Disable vertically centered
+     *
+     * @param bool $centered
+     *
+     * @return self
+     *
+     * @link https://getbootstrap.com/docs/5.1/components/modal/#vertically-centered
+     */
+    public function centered(bool $centered = true): self
+    {
+        if ($centered === $this->centered) {
+            return $this;
+        }
+
+        $new = clone $this;
+        $new->centered = $centered;
+
+        return $new;
+    }
+
+    /**
+     * Set/remove fade animation
+     *
+     * @param bool $fade
+     *
+     * @return self
+     *
+     * @link https://getbootstrap.com/docs/5.1/components/modal/#remove-animation
+     */
+    public function fade(bool $fade = true): self
+    {
+        $new = clone $this;
+        $new->fade = $fade;
+
+        return $new;
+    }
+
+    /**
+     * Enable/disable fullscreen mode
+     *
+     * @param string|null $fullscreen
+     *
+     * @return self
+     *
+     * @link https://getbootstrap.com/docs/5.1/components/modal/#fullscreen-modal
+     */
+    public function fullscreen(?string $fullscreen): self
+    {
+        $new = clone $this;
+        $new->fullscreen = $fullscreen;
 
         return $new;
     }
@@ -307,25 +511,41 @@ final class Modal extends Widget
      */
     private function renderHeader(): string
     {
-        $button = $this->renderCloseButton();
+        $title = (string) $this->renderTitle();
+        $button = (string) $this->renderCloseButton();
 
-        if ($this->title !== '') {
-            Html::addCssClass($this->titleOptions, ['titleOptions' => 'modal-title']);
-        }
-
-        $header = ($this->title === '') ? '' : Html::tag('h5', $this->title, $this->titleOptions)->render();
-
-        if ($button !== null) {
-            $header .= "\n" . $button;
-        } elseif ($header === '') {
+        if ($button === '' && $title === '') {
             return '';
         }
 
-        Html::addCssClass($this->headerOptions, ['headerOptions' => 'modal-header']);
+        $options = $this->headerOptions;
+        $tag = ArrayHelper::remove($options, 'tag', 'div');
+        $content = $title . $button;
 
-        return Html::div($header, $this->headerOptions)
-            ->encode($this->encodeTags)
-            ->render();
+        Html::addCssClass($options, ['headerOptions' => 'modal-header']);
+
+        return Html::tag($tag, $content, $options)->encode(false)->render();
+    }
+
+    /**
+     * Render title HTML markup
+     *
+     * @return string|null
+     */
+    private function renderTitle(): ?string
+    {
+        if ($this->title === null) {
+            return '';
+        }
+
+        $options = $this->titleOptions;
+        $options['id'] = $this->getTitleId();
+        $tag = ArrayHelper::remove($options, 'tag', 'h5');
+        $encode = ArrayHelper::remove($options, 'encode', $this->encodeTags);
+
+        Html::addCssClass($options, ['modal-title']);
+
+        return Html::tag($tag, $this->title, $options)->encode($encode)->render();
     }
 
     /**
@@ -337,13 +557,12 @@ final class Modal extends Widget
      */
     private function renderBodyBegin(): string
     {
-        Html::addCssClass($this->bodyOptions, ['widget' => 'modal-body']);
+        $options = $this->bodyOptions;
+        $tag = ArrayHelper::remove($options, 'tag', 'div');
 
-        if ($this->encodeTags === false) {
-            $this->bodyOptions['encode'] = false;
-        }
+        Html::addCssClass($options, ['widget' => 'modal-body']);
 
-        return Html::openTag('div', $this->bodyOptions);
+        return Html::openTag($tag, $options);
     }
 
     /**
@@ -353,7 +572,9 @@ final class Modal extends Widget
      */
     private function renderBodyEnd(): string
     {
-        return Html::closeTag('div');
+        $tag = ArrayHelper::getValue($this->bodyOptions, 'tag', 'div');
+
+        return Html::closeTag($tag);
     }
 
     /**
@@ -365,36 +586,64 @@ final class Modal extends Widget
      */
     private function renderFooter(): string
     {
-        if ($this->footer === '') {
+        if ($this->footer === null) {
             return '';
         }
 
-        Html::addCssClass($this->footerOptions, ['widget' => 'modal-footer']);
+        $options = $this->footerOptions;
+        $tag = ArrayHelper::remove($options, 'tag', 'div');
+        $encode = ArrayHelper::remove($options, 'encode', $this->encodeTags);
+        Html::addCssClass($options, ['widget' => 'modal-footer']);
 
-        return Html::div($this->footer, $this->footerOptions)
-            ->encode($this->encodeTags)
-            ->render();
+        return Html::tag($tag, $this->footer, $options)->encode($encode)->render();
     }
 
     /**
      * Renders the toggle button.
      *
+     * @param array $options additional options for current button
+     *
      * @throws JsonException
      *
-     * @return string the rendering result
+     * @return string|null the rendering result
      */
-    private function renderToggleButton(): ?string
+    public function renderToggleButton(array $options = []): ?string
     {
-        if ($this->toggleButtonEnabled === false) {
+        if ($this->toggleButton === null && count($options) === 0) {
             return null;
         }
 
-        $tag = ArrayHelper::remove($this->toggleButton, 'tag', 'button');
-        $label = ArrayHelper::remove($this->toggleButton, 'label', 'Show');
+        $options = array_merge(
+            [
+               'data-bs-toggle' => 'modal',
+            ],
+            $this->toggleButton,
+            $options
+        );
 
-        return Html::tag($tag, $label, $this->toggleButton)
-            ->encode($this->encodeTags)
-            ->render();
+        $tag = ArrayHelper::remove($options, 'tag', 'button');
+        $label = ArrayHelper::remove($options, 'label', 'Show');
+        $encode = ArrayHelper::remove($options, 'encode', $this->encodeTags);
+
+        if ($tag === 'button' && !isset($options['type'])) {
+            $options['type'] = 'button';
+        }
+
+        if (!isset($options['data-bs-target'])) {
+            $target = (string) $this->getId();
+
+            if ($tag === 'a') {
+                if (!isset($options['href'])) {
+                    $options['href'] = '#' . $target;
+                } else {
+                    $options['data-bs-target'] = '#' . $target;
+                }
+            } else {
+                $options['data-bs-target'] = '#' . $target;
+            }
+        }
+
+        return Html::tag($tag, $label, $options)->encode($encode)->render();
     }
 
     /**
@@ -402,66 +651,28 @@ final class Modal extends Widget
      *
      * @throws JsonException
      *
-     * @return string the rendering result
+     * @return string|null the rendering result
+     *
+     * @link https://getbootstrap.com/docs/5.1/components/close-button/
      */
     private function renderCloseButton(): ?string
     {
-        if ($this->closeButtonEnabled === false) {
+        if ($this->closeButton === null) {
             return null;
         }
 
-        $tag = ArrayHelper::remove($this->closeButton, 'tag', 'button');
-        $label = ArrayHelper::remove($this->closeButton, 'label', Html::span('&times;', [
-            'aria-hidden' => 'true',
-        ])->render());
-
-        return Html::tag($tag, $label, $this->closeButton)
-            ->encode($this->encodeTags)
-            ->render();
-    }
-
-    /**
-     * Initializes the widget options.
-     *
-     * This method sets the default values for various options.
-     */
-    private function initOptions(): void
-    {
-        $this->options = array_merge([
-            'class' => 'fade',
-            'role' => 'dialog',
-            'tabindex' => -1,
-            'aria-hidden' => 'true',
-        ], $this->options);
-
-        /** @psalm-suppress InvalidArgument */
-        Html::addCssClass($this->options, ['widget' => 'modal']);
-
-        $this->titleOptions = array_merge([
-            'id' => $this->options['id'] . '-label',
-        ], $this->titleOptions);
-
-        if (!isset($this->options['aria-label'], $this->options['aria-labelledby']) && $this->title !== '') {
-            $this->options['aria-labelledby'] = $this->titleOptions['id'];
-        }
-
-        if ($this->closeButtonEnabled !== false) {
-            Html::addCssClass($this->closeButton, ['closeButton' => 'close']);
-
-            $this->closeButton = array_merge([
+        $options = array_merge([
                 'data-bs-dismiss' => 'modal',
-                'type' => 'button',
+                'aria-label' => 'Close',
             ], $this->closeButton);
+        $tag = ArrayHelper::remove($options, 'tag', 'button');
+        $label = ArrayHelper::remove($options, 'label', '');
+        $encode = ArrayHelper::remove($options, 'encode', !empty($label));
+
+        if ($tag === 'button' && !isset($options['type'])) {
+            $options['type'] = 'button';
         }
 
-        if ($this->toggleButton !== []) {
-            $this->toggleButton = array_merge([
-                'data-bs-toggle' => 'modal',
-                'type' => 'button',
-            ], $this->toggleButton);
-            if (!isset($this->toggleButton['data-bs-target']) && !isset($this->toggleButton['href'])) {
-                $this->toggleButton['data-bs-target'] = '#' . $this->options['id'];
-            }
-        }
+        return Html::tag($tag, $label, $options)->encode($encode)->render();
     }
 }

--- a/src/NavBar.php
+++ b/src/NavBar.php
@@ -498,7 +498,7 @@ final class NavBar extends Widget
                 'controls' => $targetId,
                 'expanded' => 'false',
                 'label' => $this->screenReaderToggleText,
-            ]
+            ],
         ];
 
         if ($targetId) {

--- a/src/NavBar.php
+++ b/src/NavBar.php
@@ -116,6 +116,9 @@ final class NavBar extends Widget
     public const EXPAND_XL = 'navbar-expand-xl';
     public const EXPAND_XXL = 'navbar-expand-xxl';
 
+    public const THEME_LIGHT = 'navbar-light';
+    public const THEME_DARK = 'navbar-dark';
+
     private array $collapseOptions = [];
     private ?string $brandText = null;
     private ?string $brandImage = null;
@@ -130,6 +133,7 @@ final class NavBar extends Widget
     private array $options = [];
     private bool $encodeTags = false;
     private ?string $expandSize = self::EXPAND_LG;
+    private ?string $theme = self::THEME_LIGHT;
     private ?Offcanvas $offcanvas = null;
 
     public function getId(?string $suffix = '-navbar'): ?string
@@ -153,8 +157,8 @@ final class NavBar extends Widget
             $classNames['size'] = $this->expandSize;
         }
 
-        if (empty($options['class'])) {
-            $classNames = array_merge($classNames, ['navbar-light', 'bg-light']);
+        if ($this->theme) {
+            $classNames['theme'] = $this->theme;
         }
 
         Html::addCssClass($options, $classNames);
@@ -226,6 +230,21 @@ final class NavBar extends Widget
     {
         $new = clone $this;
         $new->expandSize = $size;
+
+        return $new;
+    }
+
+    /**
+     * Set color theme for NavBar
+     *
+     * @param string|null $theme
+     *
+     * @return self
+     */
+    public function theme(?string $theme): self
+    {
+        $new = clone $this;
+        $new->theme = $theme;
 
         return $new;
     }

--- a/src/NavBar.php
+++ b/src/NavBar.php
@@ -497,7 +497,7 @@ final class NavBar extends Widget
             'aria' => [
                 'controls' => $targetId,
                 'expanded' => 'false',
-                'label' => $this->screenReaderToggleText
+                'label' => $this->screenReaderToggleText,
             ]
         ];
 

--- a/src/NavBar.php
+++ b/src/NavBar.php
@@ -250,6 +250,26 @@ final class NavBar extends Widget
     }
 
     /**
+     * Short method for light navbar theme
+     *
+     * @return self
+     */
+    public function light(): self
+    {
+        return $this->theme(self::THEME_LIGHT);
+    }
+
+    /**
+     * Short method for dark navbar theme
+     *
+     * @return self
+     */
+    public function dark(): self
+    {
+        return $this->theme(self::THEME_DARK);
+    }
+
+    /**
      * The HTML attributes for the container tag. The following special options are recognized.
      *
      * @param array $value

--- a/src/Offcanvas.php
+++ b/src/Offcanvas.php
@@ -1,0 +1,288 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Bootstrap5;
+
+use Yiisoft\Arrays\ArrayHelper;
+use Yiisoft\Html\Html;
+
+final class Offcanvas extends Widget
+{
+    public const PLACEMENT_TOP = 'offcanvas-top';
+    public const PLACEMENT_END = 'offcanvas-end';
+    public const PLACEMENT_BOTTOM = 'offcanvas-bottom';
+    public const PLACEMENT_START = 'offcanvas-start';
+
+    private array $options = [];
+    private array $headerOptions = [];
+    private array $titleOptions = [];
+    private array $bodyOptions = [];
+    private array $closeButtonOptions = [];
+    private ?string $title = null;
+    private string $placement = self::PLACEMENT_START;
+    private bool $scroll = false;
+    private bool $backdrop = true;
+
+    public function getId(?string $suffix = '-offcanvas'): ?string
+    {
+        return $this->options['id'] ?? parent::getId($suffix);
+    }
+
+    /**
+     * Enable/disable body scroll when offcanvas show
+     *
+     * @return self
+     *
+     * @link https://getbootstrap.com/docs/5.1/components/offcanvas/#backdrop
+     */
+    public function scroll(bool $scroll): self
+    {
+        $new = clone $this;
+        $new->scroll = $scroll;
+
+        return $new;
+    }
+
+    /**
+     * Enable/disable offcanvas
+     *
+     * @return self
+     *
+     * @link https://getbootstrap.com/docs/5.1/components/offcanvas/#backdrop
+     */
+    public function backdrop(bool $backdrop): self
+    {
+        $new = clone $this;
+        $new->backdrop = $backdrop;
+
+        return $new;
+    }
+
+    /**
+     * Set placement for opened offcanvas
+     *
+     * @param string $placement
+     *
+     * @return self
+     *
+     * @link https://getbootstrap.com/docs/5.1/components/offcanvas/#placement
+     */
+    public function placement(string $placement): self
+    {
+        $new = clone $this;
+        $new->placement = $placement;
+
+        return $new;
+    }
+
+    /**
+     * The HTML attributes for the widget container tag. The following special options are recognized.
+     *
+     * {@see Html::renderTagAttributes()} for details on how attributes are being rendered.
+     *
+     * @param array $options
+     *
+     * @return self
+     */
+    public function options(array $options): self
+    {
+        $new = clone $this;
+        $new->options = $options;
+
+        return $new;
+    }
+
+    /**
+     * The HTML attributes for the widget header tag. The following special options are recognized.
+     *
+     * {@see Html::renderTagAttributes()} for details on how attributes are being rendered.
+     *
+     * @param array $options
+     *
+     * @return self
+     */
+    public function headerOptions(array $options): self
+    {
+        $new = clone $this;
+        $new->headerOptions = $options;
+
+        return $new;
+    }
+
+    /**
+     * Set/remove offcanvas title
+     *
+     * @param string|null $title
+     *
+     * @return self
+     */
+    public function title(?string $title): self
+    {
+        $new = clone $this;
+        $new->title = $title;
+
+        return $new;
+    }
+
+    /**
+     * The HTML attributes for the widget title tag. The following special options are recognized.
+     *
+     * {@see Html::renderTagAttributes()} for details on how attributes are being rendered.
+     *
+     * @param array $options
+     *
+     * @return self
+     */
+    public function titleOptions(array $options): self
+    {
+        $new = clone $this;
+        $new->titleOptions = $options;
+
+        return $new;
+    }
+
+    /**
+     * The HTML attributes for the widget body tag. The following special options are recognized.
+     *
+     * {@see Html::renderTagAttributes()} for details on how attributes are being rendered.
+     *
+     * @param array $options
+     *
+     * @return self
+     */
+    public function bodyOptions(array $options): self
+    {
+        $new = clone $this;
+        $new->bodyOptions = $options;
+
+        return $new;
+    }
+
+    /**
+     * The HTML attributes for the widget close button tag. The following special options are recognized.
+     *
+     * {@see Html::renderTagAttributes()} for details on how attributes are being rendered.
+     *
+     * @param array $options
+     *
+     * @return self
+     */
+    public function closeButtonOptions(array $options): self
+    {
+        $new = clone $this;
+        $new->closeButtonOptions = $options;
+
+        return $new;
+    }
+
+    public function begin(): string
+    {
+        parent::begin();
+
+        $options = $this->options;
+        $bodyOptions = $this->bodyOptions;
+        $tag = ArrayHelper::remove($options, 'tag', 'div');
+        $bodyTag = ArrayHelper::remove($bodyOptions, 'tag', 'div');
+
+        Html::addCssClass($options, ['widget' => 'offcanvas', 'placement' => $this->placement]);
+        Html::addCssClass($bodyOptions, ['widget' => 'offcanvas-body']);
+
+        $options['id'] = $this->getId();
+        $options['tabindex'] = -1;
+
+        if (!empty($this->title)) {
+            if (isset($this->titleOptions['id'])) {
+                $options['aria-labelledby'] = $this->titleOptions['id'];
+            } elseif ($options['id']) {
+                $options['aria-labelledby'] = $options['id'] . '-title';
+            }
+        }
+
+        if ($this->scroll) {
+            $options['data-bs-scroll'] = 'true';
+        }
+
+        if (!$this->backdrop) {
+            $options['data-bs-backdrop'] = 'false';
+        }
+
+        $html = Html::openTag($tag, $options);
+        $html .= $this->renderHeader();
+        $html .= Html::openTag($bodyTag, $bodyOptions);
+
+        return $html;
+    }
+
+    protected function run(): string
+    {
+        $tag = ArrayHelper::getValue($this->options, 'tag', 'div');
+        $bodyTag = ArrayHelper::getValue($this->bodyOptions, 'tag', 'div');
+
+        return Html::closeTag($bodyTag) . Html::closeTag($tag);
+    }
+
+    /**
+     * Renders offcanvas header.
+     *
+     * @return string the rendering header.
+     */
+    private function renderHeader(): string
+    {
+        $options = $this->headerOptions;
+        $tag = ArrayHelper::remove($options, 'tag', 'header');
+
+        Html::addCssClass($options, ['widget' => 'offcanvas-header']);
+
+        $title = (string) $this->renderTitle();
+        $closeButton = $this->renderCloseButton();
+
+        return Html::tag($tag, $title . $closeButton, $options)->encode(false)->render();
+    }
+
+    /**
+     * Renders offcanvas title.
+     *
+     * @return string|null the rendering header.
+     */
+    private function renderTitle(): ?string
+    {
+        if ($this->title === null) {
+            return null;
+        }
+
+        $options = $this->titleOptions;
+        $tag = ArrayHelper::remove($options, 'tag', 'h5');
+        $encode = ArrayHelper::remove($options, 'encode');
+
+        Html::addCssClass($options, ['offcanvas-title']);
+
+        if (!isset($options['id']) && $id = $this->getId()) {
+            $options['id'] = $id . '-title';
+        }
+
+        return Html::tag($tag, $this->title, $options)->encode($encode)->render();
+    }
+
+    /**
+     * Renders offcanvas close button.
+     *
+     * @return string the rendering close button.
+     */
+    private function renderCloseButton(): string
+    {
+        $options = $this->closeButtonOptions;
+        $label = ArrayHelper::remove($options, 'label');
+        $encode = ArrayHelper::remove($options, 'encode');
+
+        if ($label === null) {
+            Html::addCssClass($options, ['btn-close']);
+        }
+
+        $options['type'] = 'button';
+        $options['aria-label'] = 'Close';
+        $options['data-bs-dismiss'] = 'offcanvas';
+
+        return Html::tag('button', $label, $options)->encode($encode)->render();
+    }
+}

--- a/src/Tabs.php
+++ b/src/Tabs.php
@@ -71,7 +71,7 @@ final class Tabs extends Widget
 
     public function getId(?string $suffix = '-tabs'): ?string
     {
-        return $this->navDefinitions['options']['id'] ?? parent::getId('-tabs');
+        return $this->navDefinitions['options']['id'] ?? parent::getId($suffix);
     }
 
     protected function beforeRun(): bool

--- a/tests/AlertTest.php
+++ b/tests/AlertTest.php
@@ -201,7 +201,7 @@ final class AlertTest extends TestCase
         Alert::counter(0);
 
         if ($type === 'custom') {
-            $alert = Alert::widget()->type($type);
+            $alert = Alert::widget()->addClassNames($type);
         } else {
             $alert = Alert::widget()->{$type}();
         }

--- a/tests/AlertTest.php
+++ b/tests/AlertTest.php
@@ -13,6 +13,44 @@ use Yiisoft\Yii\Bootstrap5\Alert;
  */
 final class AlertTest extends TestCase
 {
+    private function typeDataProvider(): array
+    {
+        return [
+            Alert::TYPE_PRIMARY => [
+                'method' => 'primary',
+                'expected' => '<div id="w0-alert" class="alert alert-primary" role="alert">primary</div>',
+            ],
+            Alert::TYPE_SECONDARY => [
+                'method' => 'secondary',
+                'expected' => '<div id="w0-alert" class="alert alert-secondary" role="alert">secondary</div>',
+            ],
+            Alert::TYPE_SUCCESS => [
+                'method' => 'success',
+                'expected' => '<div id="w0-alert" class="alert alert-success" role="alert">success</div>',
+            ],
+            Alert::TYPE_DANGER => [
+                'method' => 'danger',
+                'expected' => '<div id="w0-alert" class="alert alert-danger" role="alert">danger</div>',
+            ],
+            Alert::TYPE_WARNING => [
+                'method' => 'warning',
+                'expected' => '<div id="w0-alert" class="alert alert-warning" role="alert">warning</div>',
+            ],
+            Alert::TYPE_INFO => [
+                'method' => 'info',
+                'expected' => '<div id="w0-alert" class="alert alert-info" role="alert">info</div>',
+            ],
+            Alert::TYPE_LIGHT => [
+                'method' => 'light',
+                'expected' => '<div id="w0-alert" class="alert alert-light" role="alert">light</div>',
+            ],
+            Alert::TYPE_DARK => [
+                'method' => 'dark',
+                'expected' => '<div id="w0-alert" class="alert alert-dark" role="alert">dark</div>',
+            ],
+        ];
+    }
+
     /**
      * @link https://getbootstrap.com/docs/5.0/components/alerts/#examples
      */
@@ -31,7 +69,7 @@ final class AlertTest extends TestCase
         <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="alert"></button>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($expected, $html);
+        $this->assertEqualsHTML($expected, $html);
     }
 
     /**
@@ -52,7 +90,7 @@ final class AlertTest extends TestCase
         <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="alert"></button>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($expected, $html);
+        $this->assertEqualsHTML($expected, $html);
     }
 
     /**
@@ -78,7 +116,7 @@ final class AlertTest extends TestCase
         <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="alert"></button>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($expected, $html);
+        $this->assertEqualsHTML($expected, $html);
     }
 
     /**
@@ -94,7 +132,7 @@ final class AlertTest extends TestCase
         <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="alert"></button>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($expected, $html);
+        $this->assertEqualsHTML($expected, $html);
     }
 
     public function testDismissingDisable(): void
@@ -107,7 +145,7 @@ final class AlertTest extends TestCase
 
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($expected, $html);
+        $this->assertEqualsHTML($expected, $html);
     }
 
     public function testCloseButtonOptions(): void
@@ -117,9 +155,73 @@ final class AlertTest extends TestCase
         $html = Alert::widget()->body('Message1')->closeButton(['class' => 'btn-lg'])->render();
         $expected = <<<'HTML'
         <div id="w0-alert" class="alert alert-dismissible" role="alert">Message1
-        <button type="button" class="btn-lg btn-close" aria-label="Close" data-bs-dismiss="alert"></button>
+        <button type="button" class="btn-lg" aria-label="Close" data-bs-dismiss="alert"></button>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($expected, $html);
+        $this->assertEqualsHTML($expected, $html);
+
+        Alert::counter(0);
+
+        $html = Alert::widget()->body('Message1')
+            ->closeButton([
+                'class' => 'btn-close',
+                'tag' => 'a',
+                'href' => '/',
+            ])->render();
+        $expected = <<<'HTML'
+        <div id="w0-alert" class="alert alert-dismissible" role="alert">Message1
+        <a class="btn-close" href="/" aria-label="Close" data-bs-dismiss="alert"></a>
+        </div>
+        HTML;
+        $this->assertEqualsHTML($expected, $html);
+    }
+
+    public function testFade(): void
+    {
+        Alert::counter(0);
+
+        $html = Alert::widget()->body('Message1')->fade()->render();
+        $expected = <<<'HTML'
+        <div id="w0-alert" class="alert alert-dismissible fade show" role="alert">Message1
+        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="alert"></button>
+        </div>
+        HTML;
+        $this->assertEqualsHTML($expected, $html);
+    }
+
+    public function testTypes(): void
+    {
+        $types = $this->typeDataProvider();
+
+        foreach ($types as $type => $data) {
+            Alert::counter(0);
+            $html = Alert::widget()->type($type)->body($data['method'])->withoutCloseButton()->render();
+
+            $this->assertEqualsHTML($data['expected'], $html);
+
+            Alert::counter(0);
+            $html = Alert::widget()->{$data['method']}()->body($data['method'])->withoutCloseButton()->render();
+
+            $this->assertEqualsHTML($data['expected'], $html);
+        }
+    }
+
+    public function testHeader(): void
+    {
+        Alert::counter(0);
+
+        $html = Alert::widget()->body('Message1')->header('Alert header')->headerOptions([
+            'tag' => 'h5',
+            'class' => 'header-class',
+        ])->fade()->render();
+        $expected = <<<'HTML'
+        <div id="w0-alert" class="alert alert-dismissible fade show" role="alert">
+        <h5 class="header-class alert-heading">Alert header</h5>
+        Message1
+        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="alert"></button>
+        </div>
+        HTML;
+
+        $this->assertEqualsHTML($expected, $html);
     }
 }

--- a/tests/AlertTest.php
+++ b/tests/AlertTest.php
@@ -167,7 +167,7 @@ final class AlertTest extends TestCase
         Alert::counter(0);
 
         $html = Alert::widget()->body('Message1')
-            ->buttonTag('a')
+            ->closeButtonTag('a')
             ->closeButton([
                 'class' => 'btn-close',
                 'href' => '/',

--- a/tests/AlertTest.php
+++ b/tests/AlertTest.php
@@ -13,40 +13,44 @@ use Yiisoft\Yii\Bootstrap5\Alert;
  */
 final class AlertTest extends TestCase
 {
-    private function typeDataProvider(): array
+    public function typeDataProvider(): array
     {
         return [
-            Alert::TYPE_PRIMARY => [
-                'method' => 'primary',
-                'expected' => '<div id="w0-alert" class="alert alert-primary" role="alert">primary</div>',
+            [
+                'primary',
+                '<div id="w0-alert" class="alert alert-primary" role="alert">primary</div>',
             ],
-            Alert::TYPE_SECONDARY => [
-                'method' => 'secondary',
-                'expected' => '<div id="w0-alert" class="alert alert-secondary" role="alert">secondary</div>',
+            [
+                'secondary',
+                '<div id="w0-alert" class="alert alert-secondary" role="alert">secondary</div>',
             ],
-            Alert::TYPE_SUCCESS => [
-                'method' => 'success',
-                'expected' => '<div id="w0-alert" class="alert alert-success" role="alert">success</div>',
+            [
+                'success',
+                '<div id="w0-alert" class="alert alert-success" role="alert">success</div>',
             ],
-            Alert::TYPE_DANGER => [
-                'method' => 'danger',
-                'expected' => '<div id="w0-alert" class="alert alert-danger" role="alert">danger</div>',
+            [
+                'danger',
+                '<div id="w0-alert" class="alert alert-danger" role="alert">danger</div>',
             ],
-            Alert::TYPE_WARNING => [
-                'method' => 'warning',
-                'expected' => '<div id="w0-alert" class="alert alert-warning" role="alert">warning</div>',
+            [
+                'warning',
+                '<div id="w0-alert" class="alert alert-warning" role="alert">warning</div>',
             ],
-            Alert::TYPE_INFO => [
-                'method' => 'info',
-                'expected' => '<div id="w0-alert" class="alert alert-info" role="alert">info</div>',
+            [
+                'info',
+                '<div id="w0-alert" class="alert alert-info" role="alert">info</div>',
             ],
-            Alert::TYPE_LIGHT => [
-                'method' => 'light',
-                'expected' => '<div id="w0-alert" class="alert alert-light" role="alert">light</div>',
+            [
+                'light',
+                '<div id="w0-alert" class="alert alert-light" role="alert">light</div>',
             ],
-            Alert::TYPE_DARK => [
-                'method' => 'dark',
-                'expected' => '<div id="w0-alert" class="alert alert-dark" role="alert">dark</div>',
+            [
+                'dark',
+                '<div id="w0-alert" class="alert alert-dark" role="alert">dark</div>',
+            ],
+            [
+                'custom',
+                '<div id="w0-alert" class="alert custom" role="alert">custom</div>',
             ],
         ];
     }
@@ -163,9 +167,9 @@ final class AlertTest extends TestCase
         Alert::counter(0);
 
         $html = Alert::widget()->body('Message1')
+            ->buttonTag('a')
             ->closeButton([
                 'class' => 'btn-close',
-                'tag' => 'a',
                 'href' => '/',
             ])->render();
         $expected = <<<'HTML'
@@ -189,31 +193,35 @@ final class AlertTest extends TestCase
         $this->assertEqualsHTML($expected, $html);
     }
 
-    public function testTypes(): void
+    /**
+     * @dataProvider typeDataProvider
+     */
+    public function testTypes(string $type, string $expected): void
     {
-        $types = $this->typeDataProvider();
+        Alert::counter(0);
 
-        foreach ($types as $type => $data) {
-            Alert::counter(0);
-            $html = Alert::widget()->type($type)->body($data['method'])->withoutCloseButton()->render();
-
-            $this->assertEqualsHTML($data['expected'], $html);
-
-            Alert::counter(0);
-            $html = Alert::widget()->{$data['method']}()->body($data['method'])->withoutCloseButton()->render();
-
-            $this->assertEqualsHTML($data['expected'], $html);
+        if ($type === 'custom') {
+            $alert = Alert::widget()->type($type);
+        } else {
+            $alert = Alert::widget()->{$type}();
         }
+
+        $html = $alert->body($type)->withoutCloseButton()->render();
+
+        $this->assertEqualsHTML($expected, $html);
     }
 
     public function testHeader(): void
     {
         Alert::counter(0);
 
-        $html = Alert::widget()->body('Message1')->header('Alert header')->headerOptions([
-            'tag' => 'h5',
-            'class' => 'header-class',
-        ])->fade()->render();
+        $html = Alert::widget()
+            ->body('Message1')
+            ->header('Alert header')
+            ->headerTag('h5')
+            ->headerOptions([
+                'class' => 'header-class',
+            ])->fade()->render();
         $expected = <<<'HTML'
         <div id="w0-alert" class="alert alert-dismissible fade show" role="alert">
         <h5 class="header-class alert-heading">Alert header</h5>

--- a/tests/ModalTest.php
+++ b/tests/ModalTest.php
@@ -23,12 +23,12 @@ final class ModalTest extends TestCase
             ->begin();
         $html .= Modal::end();
         $expected = <<<'HTML'
-<button>Show</button>
-<div id="w0-modal" class="fade modal" role="dialog" tabindex="-1" aria-hidden="true">
-<div class="modal-dialog ">
+<button type="button" data-bs-toggle="modal" data-bs-target="#w0-modal">Show</button>
+<div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true">
+<div class="modal-dialog">
 <div class="modal-content">
 <div class="modal-header">
-<button type="button" class="close" data-bs-dismiss="modal"><span aria-hidden="true">&amp;times;</span></button></div>
+<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>
 <div class="modal-body test" style="text-align:center;">
 
 </div>
@@ -37,7 +37,7 @@ final class ModalTest extends TestCase
 </div>
 </div>
 HTML;
-        $this->assertEqualsWithoutLE($expected, $html);
+        $this->assertEqualsHTML($expected, $html);
     }
 
     public function testFooter(): void
@@ -68,12 +68,12 @@ HTML;
         $html .= '<p>Woohoo, you\'re reading this text in a modal!</p>';
         $html .= Modal::end();
         $expected = <<<'HTML'
-<button>Show</button>
-<div id="w0-modal" class="fade modal" role="dialog" tabindex="-1" aria-hidden="true">
-<div class="modal-dialog ">
+<button type="button" data-bs-toggle="modal" data-bs-target="#w0-modal">Show</button>
+<div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true">
+<div class="modal-dialog">
 <div class="modal-content">
 <div class="modal-header">
-<button type="button" class="close" data-bs-dismiss="modal"><span aria-hidden="true">&amp;times;</span></button></div>
+<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>
 <div class="modal-body">
 <p>Woohoo, you're reading this text in a modal!</p>
 </div>
@@ -83,7 +83,7 @@ HTML;
 </div>
 </div>
 HTML;
-        $this->assertEqualsWithoutLE($expected, $html);
+        $this->assertEqualsHTML($expected, $html);
     }
 
     public function testToogleButtom(): void
@@ -119,11 +119,11 @@ HTML;
         $html .= Modal::end();
         $expected = <<<'HTML'
 <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#w0-modal">Launch demo modal</button>
-<div id="w0-modal" class="fade modal" role="dialog" tabindex="-1" aria-hidden="true">
-<div class="modal-dialog ">
+<div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true">
+<div class="modal-dialog">
 <div class="modal-content">
 <div class="modal-header">
-<button type="button" class="close" data-bs-dismiss="modal"><span aria-hidden="true">&amp;times;</span></button></div>
+<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>
 <div class="modal-body">
 <p>Woohoo, you're reading this text in a modal!</p>
 </div>
@@ -133,23 +133,23 @@ HTML;
 </div>
 </div>
 HTML;
-        $this->assertEqualsWithoutLE($expected, $html);
+        $this->assertEqualsHTML($expected, $html);
     }
 
     public function testWithCloseButton(): void
     {
         Modal::counter(0);
 
-        $html = Modal::widget()->closeButton(['class' => 'btn-lg'])->begin();
+        $html = Modal::widget()->closeButton(['class' => 'btn-lg btn-close'])->begin();
         $html .= '<p>Woohoo, you\'re reading this text in a modal!</p>';
         $html .= Modal::end();
         $expected = <<<'HTML'
-        <button>Show</button>
-        <div id="w0-modal" class="fade modal" role="dialog" tabindex="-1" aria-hidden="true">
-        <div class="modal-dialog ">
+        <button type="button" data-bs-toggle="modal" data-bs-target="#w0-modal">Show</button>
+        <div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
         <div class="modal-content">
         <div class="modal-header">
-        <button type="button" class="btn-lg close" data-bs-dismiss="modal"><span aria-hidden="true">&amp;times;</span></button></div>
+        <button type="button" class="btn-lg btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>
         <div class="modal-body">
         <p>Woohoo, you're reading this text in a modal!</p>
         </div>
@@ -158,7 +158,7 @@ HTML;
         </div>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($expected, $html);
+        $this->assertEqualsHTML($expected, $html);
     }
 
     public function testWithoutCloseButton(): void
@@ -169,9 +169,9 @@ HTML;
         $html .= '<p>Woohoo, you\'re reading this text in a modal!</p>';
         $html .= Modal::end();
         $expected = <<<'HTML'
-        <button>Show</button>
-        <div id="w0-modal" class="fade modal" role="dialog" tabindex="-1" aria-hidden="true">
-        <div class="modal-dialog ">
+        <button type="button" data-bs-toggle="modal" data-bs-target="#w0-modal">Show</button>
+        <div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
         <div class="modal-content">
 
         <div class="modal-body">
@@ -182,7 +182,7 @@ HTML;
         </div>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($expected, $html);
+        $this->assertEqualsHTML($expected, $html);
     }
 
     public function testWithFooterOptions(): void
@@ -193,12 +193,12 @@ HTML;
         $html .= '<p>Woohoo, you\'re reading this text in a modal!</p>';
         $html .= Modal::end();
         $expected = <<<'HTML'
-        <button>Show</button>
-        <div id="w0-modal" class="fade modal" role="dialog" tabindex="-1" aria-hidden="true">
-        <div class="modal-dialog ">
+        <button type="button" data-bs-toggle="modal" data-bs-target="#w0-modal">Show</button>
+        <div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
         <div class="modal-content">
         <div class="modal-header">
-        <button type="button" class="close" data-bs-dismiss="modal"><span aria-hidden="true">&amp;times;</span></button></div>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>
         <div class="modal-body">
         <p>Woohoo, you're reading this text in a modal!</p>
         </div>
@@ -207,7 +207,7 @@ HTML;
         </div>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($expected, $html);
+        $this->assertEqualsHTML($expected, $html);
     }
 
     public function testWithHeaderOptions(): void
@@ -218,12 +218,12 @@ HTML;
         $html .= '<p>Woohoo, you\'re reading this text in a modal!</p>';
         $html .= Modal::end();
         $expected = <<<'HTML'
-        <button>Show</button>
-        <div id="w0-modal" class="fade modal" role="dialog" tabindex="-1" aria-hidden="true">
-        <div class="modal-dialog ">
+        <button type="button" data-bs-toggle="modal" data-bs-target="#w0-modal">Show</button>
+        <div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
         <div class="modal-content">
         <div class="text-danger modal-header">
-        <button type="button" class="close" data-bs-dismiss="modal"><span aria-hidden="true">&amp;times;</span></button></div>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>
         <div class="modal-body">
         <p>Woohoo, you're reading this text in a modal!</p>
         </div>
@@ -232,7 +232,7 @@ HTML;
         </div>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($expected, $html);
+        $this->assertEqualsHTML($expected, $html);
     }
 
     public function testWithOptions(): void
@@ -243,12 +243,12 @@ HTML;
         $html .= '<p>Woohoo, you\'re reading this text in a modal!</p>';
         $html .= Modal::end();
         $expected = <<<'HTML'
-        <button>Show</button>
-        <div id="w0-modal" class="testMe modal" role="dialog" tabindex="-1" aria-hidden="true">
-        <div class="modal-dialog ">
+        <button type="button" data-bs-toggle="modal" data-bs-target="#w0-modal">Show</button>
+        <div id="w0-modal" class="testMe modal fade" role="dialog" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
         <div class="modal-content">
         <div class="modal-header">
-        <button type="button" class="close" data-bs-dismiss="modal"><span aria-hidden="true">&amp;times;</span></button></div>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>
         <div class="modal-body">
         <p>Woohoo, you're reading this text in a modal!</p>
         </div>
@@ -257,7 +257,7 @@ HTML;
         </div>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($expected, $html);
+        $this->assertEqualsHTML($expected, $html);
     }
 
     public function testWithTitle(): void
@@ -268,12 +268,12 @@ HTML;
         $html .= '<p>Woohoo, you\'re reading this text in a modal!</p>';
         $html .= Modal::end();
         $expected = <<<'HTML'
-        <button>Show</button>
-        <div id="w0-modal" class="fade modal" role="dialog" tabindex="-1" aria-hidden="true" aria-labelledby="w0-modal-label">
-        <div class="modal-dialog ">
+        <button type="button" data-bs-toggle="modal" data-bs-target="#w0-modal">Show</button>
+        <div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true" aria-labelledby="w0-modal-label">
+        <div class="modal-dialog">
         <div class="modal-content">
         <div class="modal-header"><h5 id="w0-modal-label" class="modal-title">My first modal.</h5>
-        <button type="button" class="close" data-bs-dismiss="modal"><span aria-hidden="true">&amp;times;</span></button></div>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>
         <div class="modal-body">
         <p>Woohoo, you're reading this text in a modal!</p>
         </div>
@@ -282,7 +282,32 @@ HTML;
         </div>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($expected, $html);
+        $this->assertEqualsHTML($expected, $html);
+    }
+
+    public function testWithEmptyTitle(): void
+    {
+        Modal::counter(0);
+
+        $html = Modal::widget()->title('')->begin();
+        $html .= '<p>Woohoo, you\'re reading this text in a modal!</p>';
+        $html .= Modal::end();
+        $expected = <<<'HTML'
+        <button type="button" data-bs-toggle="modal" data-bs-target="#w0-modal">Show</button>
+        <div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
+        <div class="modal-content">
+        <div class="modal-header"><h5 id="w0-modal-label" class="modal-title"></h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>
+        <div class="modal-body">
+        <p>Woohoo, you're reading this text in a modal!</p>
+        </div>
+
+        </div>
+        </div>
+        </div>
+        HTML;
+        $this->assertEqualsHTML($expected, $html);
     }
 
     public function testWithTitleOptions(): void
@@ -293,12 +318,12 @@ HTML;
         $html .= '<p>Woohoo, you\'re reading this text in a modal!</p>';
         $html .= Modal::end();
         $expected = <<<'HTML'
-        <button>Show</button>
-        <div id="w0-modal" class="fade modal" role="dialog" tabindex="-1" aria-hidden="true" aria-labelledby="w0-modal-label">
-        <div class="modal-dialog ">
+        <button type="button" data-bs-toggle="modal" data-bs-target="#w0-modal">Show</button>
+        <div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true" aria-labelledby="w0-modal-label">
+        <div class="modal-dialog">
         <div class="modal-content">
         <div class="modal-header"><h5 id="w0-modal-label" class="text-center modal-title">My first modal.</h5>
-        <button type="button" class="close" data-bs-dismiss="modal"><span aria-hidden="true">&amp;times;</span></button></div>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>
         <div class="modal-body">
         <p>Woohoo, you're reading this text in a modal!</p>
         </div>
@@ -307,7 +332,7 @@ HTML;
         </div>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($expected, $html);
+        $this->assertEqualsHTML($expected, $html);
     }
 
     public function testWithoutTogleButton(): void
@@ -319,11 +344,11 @@ HTML;
         $html .= Modal::end();
         $expected = <<<'HTML'
 
-        <div id="w0-modal" class="fade modal" role="dialog" tabindex="-1" aria-hidden="true">
-        <div class="modal-dialog ">
+        <div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
         <div class="modal-content">
         <div class="modal-header">
-        <button type="button" class="close" data-bs-dismiss="modal"><span aria-hidden="true">&amp;times;</span></button></div>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>
         <div class="modal-body">
         <p>Woohoo, you're reading this text in a modal!</p>
         </div>
@@ -332,7 +357,7 @@ HTML;
         </div>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($expected, $html);
+        $this->assertEqualsHTML($expected, $html);
     }
 
     public function testWithSize(): void
@@ -343,12 +368,12 @@ HTML;
         $html .= '<p>Woohoo, you\'re reading this text in a modal!</p>';
         $html .= Modal::end();
         $expected = <<<'HTML'
-        <button>Show</button>
-        <div id="w0-modal" class="fade modal" role="dialog" tabindex="-1" aria-hidden="true">
+        <button type="button" data-bs-toggle="modal" data-bs-target="#w0-modal">Show</button>
+        <div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true">
         <div class="modal-dialog modal-lg">
         <div class="modal-content">
         <div class="modal-header">
-        <button type="button" class="close" data-bs-dismiss="modal"><span aria-hidden="true">&amp;times;</span></button></div>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>
         <div class="modal-body">
         <p>Woohoo, you're reading this text in a modal!</p>
         </div>
@@ -357,18 +382,18 @@ HTML;
         </div>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($expected, $html);
+        $this->assertEqualsHTML($expected, $html);
 
         $html = Modal::widget()->size(Modal::SIZE_SMALL)->begin();
         $html .= '<p>Woohoo, you\'re reading this text in a modal!</p>';
         $html .= Modal::end();
         $expected = <<<'HTML'
-        <button>Show</button>
-        <div id="w1-modal" class="fade modal" role="dialog" tabindex="-1" aria-hidden="true">
+        <button type="button" data-bs-toggle="modal" data-bs-target="#w1-modal">Show</button>
+        <div id="w1-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true">
         <div class="modal-dialog modal-sm">
         <div class="modal-content">
         <div class="modal-header">
-        <button type="button" class="close" data-bs-dismiss="modal"><span aria-hidden="true">&amp;times;</span></button></div>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>
         <div class="modal-body">
         <p>Woohoo, you're reading this text in a modal!</p>
         </div>
@@ -377,6 +402,202 @@ HTML;
         </div>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($expected, $html);
+        $this->assertEqualsHTML($expected, $html);
+    }
+
+    public function testWithoutAnimation(): void
+    {
+        Modal::counter(0);
+
+        $html = Modal::widget()->fade(false)->begin();
+        $html .= '<p>Woohoo, you\'re reading this text in a modal!</p>';
+        $html .= Modal::end();
+        $expected = <<<'HTML'
+        <button type="button" data-bs-toggle="modal" data-bs-target="#w0-modal">Show</button>
+        <div id="w0-modal" class="modal" role="dialog" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
+        <div class="modal-content">
+        <div class="modal-header">
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>
+        <div class="modal-body">
+        <p>Woohoo, you're reading this text in a modal!</p>
+        </div>
+        </div>
+        </div>
+        </div>
+        HTML;
+
+        $this->assertEqualsHTML($expected, $html);
+    }
+
+    public function testFullscreen(): void
+    {
+        $fullscreen = [
+            Modal::FULLSCREEN_ALWAYS,
+            Modal::FULLSCREEN_BELOW_SM,
+            Modal::FULLSCREEN_BELOW_MD,
+            Modal::FULLSCREEN_BELOW_LG,
+            Modal::FULLSCREEN_BELOW_XL,
+            Modal::FULLSCREEN_BELOW_XXL,
+        ];
+
+        foreach ($fullscreen as $className) {
+            Modal::counter(0);
+
+            $html = Modal::widget()->fullscreen($className)->begin();
+            $html .= Modal::end();
+
+            $expected = <<<HTML
+            <button type="button" data-bs-toggle="modal" data-bs-target="#w0-modal">Show</button>
+            <div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true">
+            <div class="modal-dialog {$className}">
+            <div class="modal-content">
+            <div class="modal-header">
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>
+            <div class="modal-body">
+            </div>
+            </div>
+            </div>
+            </div>
+            HTML;
+
+            $this->assertEqualsHTML($expected, $html);
+        }
+    }
+
+    public function testCustomTag(): void
+    {
+        Modal::counter(0);
+
+        $html = Modal::widget()
+                ->contentOptions([
+                    'tag' => 'form',
+                    'action' => '/',
+                ])->bodyOptions([
+                    'tag' => 'fieldset',
+                ])->headerOptions([
+                    'tag' => 'header',
+                ])->titleOptions([
+                    'tag' => 'h4',
+                ])->footerOptions([
+                    'tag' => 'footer',
+                ])->title('Title')
+                ->footer('<button type="submit">Save</button>')->begin();
+        $html .= '<input type="text">';
+        $html .= Modal::end();
+
+        $expected = <<<'HTML'
+        <button type="button" data-bs-toggle="modal" data-bs-target="#w0-modal">Show</button>
+        <div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true" aria-labelledby="w0-modal-label">
+        <div class="modal-dialog">
+        <form class="modal-content" action="/">
+        <header class="modal-header">
+        <h4 id="w0-modal-label" class="modal-title">Title</h4>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </header>
+        <fieldset class="modal-body">
+        <input type="text">
+        </fieldset>
+        <footer class="modal-footer"><button type="submit">Save</button></footer>
+        </form>
+        </div>
+        </div>
+        HTML;
+
+        $this->assertEqualsHTML($expected, $html);
+    }
+
+    public function testStaticBackdrop(): void
+    {
+        Modal::counter(0);
+
+        $html = Modal::widget()->staticBackdrop()->begin();
+        $html .= Modal::end();
+
+        $expected = <<<HTML
+        <button type="button" data-bs-toggle="modal" data-bs-target="#w0-modal">Show</button>
+        <div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true" data-bs-backdrop="static">
+        <div class="modal-dialog">
+        <div class="modal-content">
+        <div class="modal-header">
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>
+        <div class="modal-body">
+        </div>
+        </div>
+        </div>
+        </div>
+        HTML;
+
+        $this->assertEqualsHTML($expected, $html);
+    }
+
+    public function testScrollingLongContent(): void
+    {
+        Modal::counter(0);
+
+        $html = Modal::widget()->scrollable()->begin();
+        $html .= Modal::end();
+
+        $expected = <<<HTML
+        <button type="button" data-bs-toggle="modal" data-bs-target="#w0-modal">Show</button>
+        <div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-scrollable">
+        <div class="modal-content">
+        <div class="modal-header">
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>
+        <div class="modal-body">
+        </div>
+        </div>
+        </div>
+        </div>
+        HTML;
+
+        $this->assertEqualsHTML($expected, $html);
+    }
+
+    public function testVerticallyCentered(): void
+    {
+        Modal::counter(0);
+
+        $html = Modal::widget()->centered()->begin();
+        $html .= Modal::end();
+
+        $expected = <<<HTML
+        <button type="button" data-bs-toggle="modal" data-bs-target="#w0-modal">Show</button>
+        <div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+        <div class="modal-header">
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>
+        <div class="modal-body">
+        </div>
+        </div>
+        </div>
+        </div>
+        HTML;
+
+        $this->assertEqualsHTML($expected, $html);
+    }
+
+    public function testManyTogglers(): void
+    {
+        Modal::counter(0);
+        $widget =  Modal::widget();
+
+        $html = $widget->renderToggleButton();
+        $html .= $widget->renderToggleButton(['label' => 'New Label']);
+        $html .= $widget->renderToggleButton(['class' => 'btn btn-primary', 'label' => 'New Label 2']);
+        $html .= $widget->renderToggleButton(['tag' => 'a']);
+        $html .= $widget->renderToggleButton(['tag' => 'a', 'href' => '/']);
+
+        $expected = <<<HTML
+        <button type="button" data-bs-toggle="modal" data-bs-target="#w0-modal">Show</button>
+        <button type="button" data-bs-toggle="modal" data-bs-target="#w0-modal">New Label</button>
+        <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#w0-modal">New Label 2</button>
+        <a href="#w0-modal" data-bs-toggle="modal">Show</a>
+        <a href="/" data-bs-toggle="modal" data-bs-target="#w0-modal">Show</a>
+        HTML;
+
+        $this->assertEqualsHTML($expected, $html);
     }
 }

--- a/tests/NavBarTest.php
+++ b/tests/NavBarTest.php
@@ -446,7 +446,7 @@ final class NavBarTest extends TestCase
         $expected = <<<'HTML'
         <nav id="w0-navbar" class="navbar navbar-light">
         <div class="container-fluid">
-        <button  type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#navbarToggleExternalContent" aria-controls="navbarToggleExternalContent" aria-expanded="false" aria-label="Toggle navigation">
+        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#navbarToggleExternalContent" aria-controls="navbarToggleExternalContent" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
         </button>
         </div>

--- a/tests/NavBarTest.php
+++ b/tests/NavBarTest.php
@@ -27,11 +27,11 @@ final class NavBarTest extends TestCase
             ->begin();
         $html .= NavBar::end();
         $expected = <<<'HTML'
-        <nav id="w0-navbar" class="navbar-inverse navbar-static-top navbar-frontend navbar">
+        <nav id="w0-navbar" class="navbar-inverse navbar-static-top navbar-frontend navbar navbar-expand-lg">
         <div class="container">
         <a class="navbar-brand" href="/">My Company</a>
-        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-collapse" aria-controls="w0-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
-        <div id="w0-collapse" class="collapse navbar-collapse">
+        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-navbar-collapse" aria-controls="w0-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
+        <div id="w0-navbar-collapse" class="collapse navbar-collapse">
         </div>
         </div>
         </nav>
@@ -126,8 +126,8 @@ final class NavBarTest extends TestCase
         <nav id="w0-navbar" class="navbar navbar-expand-lg navbar-light bg-light">
         <div class="container">
         <a class="navbar-brand" href="/">My Company</a>
-        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-collapse" aria-controls="w0-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
-        <div id="w0-collapse" class="collapse navbar-collapse">
+        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-navbar-collapse" aria-controls="w0-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
+        <div id="w0-navbar-collapse" class="collapse navbar-collapse">
         <ul id="w1-nav" class="mr-auto nav"><li class="nav-item"><a class="nav-link" href="#">Home</a></li>
         <li class="nav-item"><a class="nav-link" href="#">Link</a></li>
         <li class="dropdown nav-item"><a class="dropdown-toggle nav-link" href="#" data-bs-toggle="dropdown">Dropdown</a><ul id="w2-dropdown" class="dropdown-menu" aria-expanded="false">
@@ -155,8 +155,8 @@ final class NavBarTest extends TestCase
         <nav id="w0-navbar" class="navbar navbar-expand-lg navbar-light bg-light">
         <div class="container">
 
-        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-collapse" aria-controls="w0-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
-        <div id="w0-collapse" class="testMe collapse navbar-collapse">
+        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-navbar-collapse" aria-controls="w0-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
+        <div id="w0-navbar-collapse" class="testMe collapse navbar-collapse">
         </div>
         </div>
         </nav>
@@ -174,8 +174,27 @@ final class NavBarTest extends TestCase
         <nav id="w0-navbar" class="navbar navbar-expand-lg navbar-light bg-light">
         <div class="container">
         <a class="text-dark navbar-brand" href="/">My App</a>
-        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-collapse" aria-controls="w0-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
-        <div id="w0-collapse" class="collapse navbar-collapse">
+        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-navbar-collapse" aria-controls="w0-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
+        <div id="w0-navbar-collapse" class="collapse navbar-collapse">
+        </div>
+        </div>
+        </nav>
+        HTML;
+        $this->assertEqualsWithoutLE($expected, $html);
+    }
+
+    public function testBrandImageAttributes(): void
+    {
+        NavBar::counter(0);
+
+        $html = NavBar::widget()->brandImage('empty.gif')->brandImageAttributes(['width' => 100, 'height' => 100])->begin();
+        $html .= NavBar::end();
+        $expected = <<<'HTML'
+        <nav id="w0-navbar" class="navbar navbar-expand-lg navbar-light bg-light">
+        <div class="container">
+        <a class="navbar-brand" href="/"><img src="empty.gif" width="100" height="100" alt></a>
+        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-navbar-collapse" aria-controls="w0-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
+        <div id="w0-navbar-collapse" class="collapse navbar-collapse">
         </div>
         </div>
         </nav>
@@ -193,8 +212,8 @@ final class NavBarTest extends TestCase
         <nav id="w0-navbar" class="navbar navbar-expand-lg navbar-light bg-light">
         <div class="container">
 
-        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-collapse" aria-controls="w0-collapse" aria-expanded="false" aria-label="Toggler navigation"><span class="navbar-toggler-icon"></span></button>
-        <div id="w0-collapse" class="collapse navbar-collapse">
+        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-navbar-collapse" aria-controls="w0-navbar-collapse" aria-expanded="false" aria-label="Toggler navigation"><span class="navbar-toggler-icon"></span></button>
+        <div id="w0-navbar-collapse" class="collapse navbar-collapse">
         </div>
         </div>
         </nav>
@@ -212,8 +231,8 @@ final class NavBarTest extends TestCase
         <nav id="w0-navbar" class="navbar navbar-expand-lg navbar-light bg-light">
         <div class="container">
 
-        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-collapse" aria-controls="w0-collapse" aria-expanded="false" aria-label="Toggle navigation"><div class="navbar-toggler-icon"></div></button>
-        <div id="w0-collapse" class="collapse navbar-collapse">
+        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-navbar-collapse" aria-controls="w0-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><div class="navbar-toggler-icon"></div></button>
+        <div id="w0-navbar-collapse" class="collapse navbar-collapse">
         </div>
         </div>
         </nav>
@@ -231,8 +250,8 @@ final class NavBarTest extends TestCase
         <nav id="w0-navbar" class="navbar navbar-expand-lg navbar-light bg-light">
         <div class="container">
 
-        <button type="button" class="testMe navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-collapse" aria-controls="w0-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
-        <div id="w0-collapse" class="collapse navbar-collapse">
+        <button type="button" class="testMe navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-navbar-collapse" aria-controls="w0-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
+        <div id="w0-navbar-collapse" class="collapse navbar-collapse">
         </div>
         </div>
         </nav>
@@ -249,8 +268,8 @@ final class NavBarTest extends TestCase
         $expected = <<<'HTML'
         <nav id="w0-navbar" class="navbar navbar-expand-lg navbar-light bg-light">
 
-        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-collapse" aria-controls="w0-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
-        <div id="w0-collapse" class="collapse navbar-collapse">
+        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-navbar-collapse" aria-controls="w0-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
+        <div id="w0-navbar-collapse" class="collapse navbar-collapse">
         </div>
         </nav>
         HTML;
@@ -267,12 +286,81 @@ final class NavBarTest extends TestCase
         <nav id="w0-navbar" class="navbar navbar-expand-lg navbar-light bg-light">
         <div class="text-link">
 
-        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-collapse" aria-controls="w0-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
-        <div id="w0-collapse" class="collapse navbar-collapse">
+        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-navbar-collapse" aria-controls="w0-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
+        <div id="w0-navbar-collapse" class="collapse navbar-collapse">
         </div>
         </div>
         </nav>
         HTML;
         $this->assertEqualsWithoutLE($expected, $html);
+    }
+
+    public function testWithoutCollapse(): void
+    {
+        NavBar::counter(0);
+
+        $html = NavBar::widget()->brandText('My Company')->expandSize(null)->brandUrl('/')->begin();
+        $html .= Nav::widget()
+            ->items([
+                ['label' => 'Home', 'url' => '#'],
+                ['label' => 'Link', 'url' => '#'],
+                ['label' => 'Dropdown', 'items' => [
+                    ['label' => 'Action', 'url' => '#'],
+                    ['label' => 'Another action', 'url' => '#'],
+                    '-',
+                    ['label' => 'Something else here', 'url' => '#'],
+                ],
+                ],
+            ])
+            ->options(['class' => ['mr-auto']])
+            ->render();
+        $html .= NavBar::end();
+
+        $expected = <<<'HTML'
+        <nav id="w0-navbar" class="navbar navbar-light bg-light">
+        <div class="container">
+        <a class="navbar-brand" href="/">My Company</a>
+        <ul id="w1-nav" class="mr-auto nav"><li class="nav-item"><a class="nav-link" href="#">Home</a></li>
+        <li class="nav-item"><a class="nav-link" href="#">Link</a></li>
+        <li class="dropdown nav-item"><a class="dropdown-toggle nav-link" href="#" data-bs-toggle="dropdown">Dropdown</a><ul id="w2-dropdown" class="dropdown-menu" aria-expanded="false">
+        <li><a class="dropdown-item" href="#">Action</a></li>
+        <li><a class="dropdown-item" href="#">Another action</a></li>
+        <li><hr class="dropdown-divider"></li>
+        <li><a class="dropdown-item" href="#">Something else here</a></li>
+        </ul></li></ul></div>
+        </nav>
+        HTML;
+        $this->assertEqualsWithoutLE($expected, $html);
+    }
+
+    public function testExpandSize(): void
+    {
+        $sizes = [
+            NavBar::EXPAND_SM,
+            NavBar::EXPAND_MD,
+            NavBar::EXPAND_LG,
+            NavBar::EXPAND_XL,
+            NavBar::EXPAND_XXL,
+        ];
+
+        $NavBar = NavBar::widget()->options([
+            'id' => 'expanded-navbar'
+        ]);
+
+        foreach ($sizes as $size) {
+            $html = $NavBar->expandSize($size)->begin() . NavBar::end();
+            $expected = <<<HTML
+            <nav id="expanded-navbar" class="navbar {$size} navbar-light bg-light">
+            <div class="container">
+
+            <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#expanded-navbar-collapse" aria-controls="expanded-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
+            <div id="expanded-navbar-collapse" class="collapse navbar-collapse">
+            </div>
+            </div>
+            </nav>
+            HTML;
+
+            $this->assertEqualsWithoutLE($expected, $html);
+        }
     }
 }

--- a/tests/NavBarTest.php
+++ b/tests/NavBarTest.php
@@ -438,7 +438,7 @@ final class NavBarTest extends TestCase
             ],
             'aria' => [
                 'controls' => 'navbarToggleExternalContent',
-            ]
+            ],
         ])->expandSize(null)->begin();
         $html .= NavBar::end();
 

--- a/tests/NavBarTest.php
+++ b/tests/NavBarTest.php
@@ -22,6 +22,7 @@ final class NavBarTest extends TestCase
         $html = NavBar::widget()
             ->brandText('My Company')
             ->brandUrl('/')
+            ->theme(null)
             ->options([
                 'class' => 'navbar-inverse navbar-static-top navbar-frontend',
             ])
@@ -124,7 +125,7 @@ final class NavBarTest extends TestCase
 
         $html .= NavBar::end();
         $expected = <<<'HTML'
-        <nav id="w0-navbar" class="navbar navbar-expand-lg navbar-light bg-light">
+        <nav id="w0-navbar" class="navbar navbar-expand-lg navbar-light">
         <div class="container">
         <a class="navbar-brand" href="/">My Company</a>
         <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-navbar-collapse" aria-controls="w0-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
@@ -153,7 +154,7 @@ final class NavBarTest extends TestCase
         $html = NavBar::widget()->collapseOptions(['class' => 'testMe'])->begin();
         $html .= NavBar::end();
         $expected = <<<'HTML'
-        <nav id="w0-navbar" class="navbar navbar-expand-lg navbar-light bg-light">
+        <nav id="w0-navbar" class="navbar navbar-expand-lg navbar-light">
         <div class="container">
 
         <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-navbar-collapse" aria-controls="w0-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
@@ -172,7 +173,7 @@ final class NavBarTest extends TestCase
         $html = NavBar::widget()->brandText('My App')->brandOptions(['class' => 'text-dark'])->begin();
         $html .= NavBar::end();
         $expected = <<<'HTML'
-        <nav id="w0-navbar" class="navbar navbar-expand-lg navbar-light bg-light">
+        <nav id="w0-navbar" class="navbar navbar-expand-lg navbar-light">
         <div class="container">
         <a class="text-dark navbar-brand" href="/">My App</a>
         <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-navbar-collapse" aria-controls="w0-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
@@ -191,7 +192,7 @@ final class NavBarTest extends TestCase
         $html = NavBar::widget()->brandImage('empty.gif')->brandImageAttributes(['width' => 100, 'height' => 100])->begin();
         $html .= NavBar::end();
         $expected = <<<'HTML'
-        <nav id="w0-navbar" class="navbar navbar-expand-lg navbar-light bg-light">
+        <nav id="w0-navbar" class="navbar navbar-expand-lg navbar-light">
         <div class="container">
         <a class="navbar-brand" href="/"><img src="empty.gif" width="100" height="100" alt></a>
         <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-navbar-collapse" aria-controls="w0-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
@@ -210,7 +211,7 @@ final class NavBarTest extends TestCase
         $html = NavBar::widget()->screenReaderToggleText('Toggler navigation')->begin();
         $html .= NavBar::end();
         $expected = <<<'HTML'
-        <nav id="w0-navbar" class="navbar navbar-expand-lg navbar-light bg-light">
+        <nav id="w0-navbar" class="navbar navbar-expand-lg navbar-light">
         <div class="container">
 
         <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-navbar-collapse" aria-controls="w0-navbar-collapse" aria-expanded="false" aria-label="Toggler navigation"><span class="navbar-toggler-icon"></span></button>
@@ -229,7 +230,7 @@ final class NavBarTest extends TestCase
         $html = NavBar::widget()->togglerContent('<div class="navbar-toggler-icon"></div>')->begin();
         $html .= NavBar::end();
         $expected = <<<'HTML'
-        <nav id="w0-navbar" class="navbar navbar-expand-lg navbar-light bg-light">
+        <nav id="w0-navbar" class="navbar navbar-expand-lg navbar-light">
         <div class="container">
 
         <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-navbar-collapse" aria-controls="w0-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><div class="navbar-toggler-icon"></div></button>
@@ -248,7 +249,7 @@ final class NavBarTest extends TestCase
         $html = NavBar::widget()->togglerOptions(['class' => 'testMe'])->begin();
         $html .= NavBar::end();
         $expected = <<<'HTML'
-        <nav id="w0-navbar" class="navbar navbar-expand-lg navbar-light bg-light">
+        <nav id="w0-navbar" class="navbar navbar-expand-lg navbar-light">
         <div class="container">
 
         <button type="button" class="testMe navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-navbar-collapse" aria-controls="w0-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
@@ -267,7 +268,7 @@ final class NavBarTest extends TestCase
         $html = NavBar::widget()->withoutRenderInnerContainer()->begin();
         $html .= NavBar::end();
         $expected = <<<'HTML'
-        <nav id="w0-navbar" class="navbar navbar-expand-lg navbar-light bg-light">
+        <nav id="w0-navbar" class="navbar navbar-expand-lg navbar-light">
 
         <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-navbar-collapse" aria-controls="w0-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
         <div id="w0-navbar-collapse" class="collapse navbar-collapse">
@@ -284,7 +285,7 @@ final class NavBarTest extends TestCase
         $html = NavBar::widget()->innerContainerOptions(['class' => 'text-link'])->begin();
         $html .= NavBar::end();
         $expected = <<<'HTML'
-        <nav id="w0-navbar" class="navbar navbar-expand-lg navbar-light bg-light">
+        <nav id="w0-navbar" class="navbar navbar-expand-lg navbar-light">
         <div class="text-link">
 
         <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-navbar-collapse" aria-controls="w0-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
@@ -318,7 +319,7 @@ final class NavBarTest extends TestCase
         $html .= NavBar::end();
 
         $expected = <<<'HTML'
-        <nav id="w0-navbar" class="navbar navbar-light bg-light">
+        <nav id="w0-navbar" class="navbar navbar-light">
         <div class="container">
         <a class="navbar-brand" href="/">My Company</a>
         <ul id="w1-nav" class="mr-auto nav"><li class="nav-item"><a class="nav-link" href="#">Home</a></li>
@@ -351,7 +352,7 @@ final class NavBarTest extends TestCase
         foreach ($sizes as $size) {
             $html = $NavBar->expandSize($size)->begin() . NavBar::end();
             $expected = <<<HTML
-            <nav id="expanded-navbar" class="navbar {$size} navbar-light bg-light">
+            <nav id="expanded-navbar" class="navbar {$size} navbar-light">
             <div class="container">
             <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#expanded-navbar-collapse" aria-controls="expanded-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
             <div id="expanded-navbar-collapse" class="collapse navbar-collapse">
@@ -374,7 +375,7 @@ final class NavBarTest extends TestCase
         $html .= NavBar::end();
 
         $expected = <<<'HTML'
-        <nav id="w1-navbar" class="navbar navbar-light bg-light">
+        <nav id="w1-navbar" class="navbar navbar-light">
         <div class="container">
         <button type="button" class="navbar-toggler" data-bs-toggle="offcanvas" data-bs-target="#w0-offcanvas" aria-controls="w0-offcanvas" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
@@ -405,7 +406,7 @@ final class NavBarTest extends TestCase
         $html .= NavBar::end();
 
         $expected = <<<'HTML'
-        <nav id="w1-navbar" class="navbar navbar-expand-xl navbar-light bg-light">
+        <nav id="w1-navbar" class="navbar navbar-expand-xl navbar-light">
         <div class="container">
         <button type="button" class="navbar-toggler" data-bs-toggle="offcanvas" data-bs-target="#w0-offcanvas" aria-controls="w0-offcanvas" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
@@ -443,7 +444,7 @@ final class NavBarTest extends TestCase
         $html .= NavBar::end();
 
         $expected = <<<'HTML'
-        <nav id="w0-navbar" class="navbar navbar-light bg-light">
+        <nav id="w0-navbar" class="navbar navbar-light">
         <div class="container-fluid">
         <button  type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#navbarToggleExternalContent" aria-controls="navbarToggleExternalContent" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
@@ -453,5 +454,40 @@ final class NavBarTest extends TestCase
         HTML;
 
         $this->assertEqualsHTML($expected, $html);
+    }
+
+    public function testColorTheme(): void
+    {
+        $themes = [
+            NavBar::THEME_LIGHT => [
+                'bg-light',
+                'bg-white',
+            ],
+            NavBar::THEME_DARK => [
+                'bg-dark',
+                'bg-primary',
+            ],
+        ];
+
+        foreach ($themes as $theme => $classNames) {
+            foreach ($classNames as $class) {
+                $html = NavBar::widget()->theme($theme)->options([
+                        'class' => $class,
+                        'id' => 'expanded-navbar',
+                    ])->begin();
+                $html .= NavBar::end();
+                $expected = <<<HTML
+                <nav id="expanded-navbar" class="{$class} navbar navbar-expand-lg {$theme}">
+                <div class="container">
+                <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#expanded-navbar-collapse" aria-controls="expanded-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
+                <div id="expanded-navbar-collapse" class="collapse navbar-collapse">
+                </div>
+                </div>
+                </nav>
+                HTML;
+
+                $this->assertEqualsHTML($expected, $html);
+            }
+        }
     }
 }

--- a/tests/NavBarTest.php
+++ b/tests/NavBarTest.php
@@ -437,7 +437,7 @@ final class NavBarTest extends TestCase
                 'bs-target' => '#navbarToggleExternalContent',
             ],
             'aria' => [
-                'controls' => 'navbarToggleExternalContent'
+                'controls' => 'navbarToggleExternalContent',
             ]
         ])->expandSize(null)->begin();
         $html .= NavBar::end();

--- a/tests/NavBarTest.php
+++ b/tests/NavBarTest.php
@@ -6,6 +6,7 @@ namespace Yiisoft\Yii\Bootstrap5\Tests;
 
 use Yiisoft\Yii\Bootstrap5\Nav;
 use Yiisoft\Yii\Bootstrap5\NavBar;
+use Yiisoft\Yii\Bootstrap5\Offcanvas;
 
 /**
  * Tests for NavBar widget.
@@ -36,7 +37,7 @@ final class NavBarTest extends TestCase
         </div>
         </nav>
         HTML;
-        $this->assertEqualsWithoutLE($expected, $html);
+        $this->assertEqualsHTML($expected, $html);
     }
 
     public function testBrandImage(): void
@@ -142,7 +143,7 @@ final class NavBarTest extends TestCase
         </div>
         </nav>
         HTML;
-        $this->assertEqualsWithoutLE($expected, $html);
+        $this->assertEqualsHTML($expected, $html);
     }
 
     public function testCollapseOptions(): void
@@ -161,7 +162,7 @@ final class NavBarTest extends TestCase
         </div>
         </nav>
         HTML;
-        $this->assertEqualsWithoutLE($expected, $html);
+        $this->assertEqualsHTML($expected, $html);
     }
 
     public function testBrandOptions(): void
@@ -180,7 +181,7 @@ final class NavBarTest extends TestCase
         </div>
         </nav>
         HTML;
-        $this->assertEqualsWithoutLE($expected, $html);
+        $this->assertEqualsHTML($expected, $html);
     }
 
     public function testBrandImageAttributes(): void
@@ -199,7 +200,7 @@ final class NavBarTest extends TestCase
         </div>
         </nav>
         HTML;
-        $this->assertEqualsWithoutLE($expected, $html);
+        $this->assertEqualsHTML($expected, $html);
     }
 
     public function testScreenReaderToggleText(): void
@@ -218,7 +219,7 @@ final class NavBarTest extends TestCase
         </div>
         </nav>
         HTML;
-        $this->assertEqualsWithoutLE($expected, $html);
+        $this->assertEqualsHTML($expected, $html);
     }
 
     public function testTogglerContent(): void
@@ -237,7 +238,7 @@ final class NavBarTest extends TestCase
         </div>
         </nav>
         HTML;
-        $this->assertEqualsWithoutLE($expected, $html);
+        $this->assertEqualsHTML($expected, $html);
     }
 
     public function testTogglerOptions(): void
@@ -256,7 +257,7 @@ final class NavBarTest extends TestCase
         </div>
         </nav>
         HTML;
-        $this->assertEqualsWithoutLE($expected, $html);
+        $this->assertEqualsHTML($expected, $html);
     }
 
     public function testRenderInnerContainer(): void
@@ -273,7 +274,7 @@ final class NavBarTest extends TestCase
         </div>
         </nav>
         HTML;
-        $this->assertEqualsWithoutLE($expected, $html);
+        $this->assertEqualsHTML($expected, $html);
     }
 
     public function testInnerContainerOptions(): void
@@ -292,7 +293,7 @@ final class NavBarTest extends TestCase
         </div>
         </nav>
         HTML;
-        $this->assertEqualsWithoutLE($expected, $html);
+        $this->assertEqualsHTML($expected, $html);
     }
 
     public function testWithoutCollapse(): void
@@ -330,7 +331,7 @@ final class NavBarTest extends TestCase
         </ul></li></ul></div>
         </nav>
         HTML;
-        $this->assertEqualsWithoutLE($expected, $html);
+        $this->assertEqualsHTML($expected, $html);
     }
 
     public function testExpandSize(): void
@@ -344,7 +345,7 @@ final class NavBarTest extends TestCase
         ];
 
         $NavBar = NavBar::widget()->options([
-            'id' => 'expanded-navbar'
+            'id' => 'expanded-navbar',
         ]);
 
         foreach ($sizes as $size) {
@@ -352,7 +353,6 @@ final class NavBarTest extends TestCase
             $expected = <<<HTML
             <nav id="expanded-navbar" class="navbar {$size} navbar-light bg-light">
             <div class="container">
-
             <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#expanded-navbar-collapse" aria-controls="expanded-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
             <div id="expanded-navbar-collapse" class="collapse navbar-collapse">
             </div>
@@ -360,7 +360,98 @@ final class NavBarTest extends TestCase
             </nav>
             HTML;
 
-            $this->assertEqualsWithoutLE($expected, $html);
+            $this->assertEqualsHTML($expected, $html);
         }
+    }
+
+    public function testOffcanvas(): void
+    {
+        NavBar::counter(0);
+
+        $offcanvas = Offcanvas::widget()->title('Navbar offcanvas title');
+        $html = NavBar::widget()->offcanvas($offcanvas)->expandSize(null)->begin();
+        $html .= '<p>Some content in navbar offcanvas</p>';
+        $html .= NavBar::end();
+
+        $expected = <<<'HTML'
+        <nav id="w1-navbar" class="navbar navbar-light bg-light">
+        <div class="container">
+        <button type="button" class="navbar-toggler" data-bs-toggle="offcanvas" data-bs-target="#w0-offcanvas" aria-controls="w0-offcanvas" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+        </button>
+        <div id="w0-offcanvas" class="offcanvas offcanvas-start" tabindex="-1" aria-labelledby="w0-offcanvas-title">
+        <header class="offcanvas-header">
+        <h5 id="w0-offcanvas-title" class="offcanvas-title">Navbar offcanvas title</h5>
+        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="offcanvas"></button>
+        </header>
+        <div class="offcanvas-body">
+        <p>Some content in navbar offcanvas</p>
+        </div>
+        </div>
+        </div>
+        </nav>
+        HTML;
+
+        $this->assertEqualsHTML($expected, $html);
+    }
+
+    public function testExpandedOffcanvas(): void
+    {
+        NavBar::counter(0);
+
+        $offcanvas = Offcanvas::widget()->title('Navbar offcanvas title');
+        $html = NavBar::widget()->offcanvas($offcanvas)->expandSize(NavBar::EXPAND_XL)->begin();
+        $html .= '<p>Some content in navbar offcanvas</p>';
+        $html .= NavBar::end();
+
+        $expected = <<<'HTML'
+        <nav id="w1-navbar" class="navbar navbar-expand-xl navbar-light bg-light">
+        <div class="container">
+        <button type="button" class="navbar-toggler" data-bs-toggle="offcanvas" data-bs-target="#w0-offcanvas" aria-controls="w0-offcanvas" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+        </button>
+        <div id="w0-offcanvas" class="offcanvas offcanvas-start" tabindex="-1" aria-labelledby="w0-offcanvas-title">
+        <header class="offcanvas-header">
+        <h5 id="w0-offcanvas-title" class="offcanvas-title">Navbar offcanvas title</h5>
+        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="offcanvas"></button>
+        </header>
+        <div class="offcanvas-body">
+        <p>Some content in navbar offcanvas</p>
+        </div>
+        </div>
+        </div>
+        </nav>
+        HTML;
+
+        $this->assertEqualsHTML($expected, $html);
+    }
+
+    public function testCollapseExternalContent(): void
+    {
+        NavBar::counter(0);
+
+        $html = NavBar::widget()->innerContainerOptions([
+            'class' => 'container-fluid',
+        ])->togglerOptions([
+            'data' => [
+                'bs-target' => '#navbarToggleExternalContent',
+            ],
+            'aria' => [
+                'controls' => 'navbarToggleExternalContent'
+            ]
+        ])->expandSize(null)->begin();
+        $html .= NavBar::end();
+
+        $expected = <<<'HTML'
+        <nav id="w0-navbar" class="navbar navbar-light bg-light">
+        <div class="container-fluid">
+        <button  type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#navbarToggleExternalContent" aria-controls="navbarToggleExternalContent" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+        </button>
+        </div>
+        </nav>
+        HTML;
+
+        $this->assertEqualsHTML($expected, $html);
     }
 }

--- a/tests/OffcanvasTest.php
+++ b/tests/OffcanvasTest.php
@@ -1,0 +1,256 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Bootstrap5\Tests;
+
+use Yiisoft\Yii\Bootstrap5\Offcanvas;
+
+final class OffcanvasTest extends TestCase
+{
+    public function testRender(): void
+    {
+        Offcanvas::counter(0);
+
+        $html = Offcanvas::widget()->title('Offcanvas title')->begin();
+        $html .= '<p>Some content here</p>';
+        $html .= Offcanvas::end();
+
+        $expected = <<<'HTML'
+        <div id="w0-offcanvas" class="offcanvas offcanvas-start" tabindex="-1" aria-labelledby="w0-offcanvas-title">
+        <header class="offcanvas-header">
+        <h5 id="w0-offcanvas-title" class="offcanvas-title">Offcanvas title</h5>
+        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="offcanvas"></button>
+        </header>
+        <div class="offcanvas-body">
+        <p>Some content here</p>
+        </div>
+        </div>
+        HTML;
+
+        $this->assertEqualsHTML($expected, $html);
+    }
+
+    public function testOptions(): void
+    {
+        Offcanvas::counter(0);
+
+        $html = Offcanvas::widget()->options([
+            'class' => 'custom-class',
+            'data-custom' => 'custom-data'
+        ])->title('Offcanvas title')->begin();
+        $html .= '<p>Some content here</p>';
+        $html .= Offcanvas::end();
+
+        $expected = <<<'HTML'
+        <div id="w0-offcanvas" class="custom-class offcanvas offcanvas-start" data-custom="custom-data" tabindex="-1" aria-labelledby="w0-offcanvas-title">
+        <header class="offcanvas-header">
+        <h5 id="w0-offcanvas-title" class="offcanvas-title">Offcanvas title</h5>
+        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="offcanvas"></button>
+        </header>
+        <div class="offcanvas-body">
+        <p>Some content here</p>
+        </div>
+        </div>
+        HTML;
+
+        $this->assertEqualsHTML($expected, $html);
+    }
+
+    public function testHeaderOptions(): void
+    {
+        Offcanvas::counter(0);
+
+        $html = Offcanvas::widget()->headerOptions([
+            'tag' => 'div',
+            'class' => 'custom-class',
+            'data-custom' => 'custom-data'
+        ])->title('Offcanvas title')->begin();
+        $html .= '<p>Some content here</p>';
+        $html .= Offcanvas::end();
+
+        $expected = <<<'HTML'
+        <div id="w0-offcanvas" class="offcanvas offcanvas-start" tabindex="-1" aria-labelledby="w0-offcanvas-title">
+        <div class="custom-class offcanvas-header" data-custom="custom-data" >
+        <h5 id="w0-offcanvas-title" class="offcanvas-title">Offcanvas title</h5>
+        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="offcanvas"></button>
+        </div>
+        <div class="offcanvas-body">
+        <p>Some content here</p>
+        </div>
+        </div>
+        HTML;
+
+        $this->assertEqualsHTML($expected, $html);
+    }
+
+    public function testTitleOptions(): void
+    {
+        Offcanvas::counter(0);
+
+        $html = Offcanvas::widget()->title('Offcanvas title')->titleOptions([
+            'tag' => 'h2',
+            'class' => 'h4'
+        ])->begin();
+        $html .= '<p>Some content here</p>';
+        $html .= Offcanvas::end();
+
+        $expected = <<<'HTML'
+        <div id="w0-offcanvas" class="offcanvas offcanvas-start" tabindex="-1" aria-labelledby="w0-offcanvas-title">
+        <header class="offcanvas-header">
+        <h2 id="w0-offcanvas-title" class="h4 offcanvas-title">Offcanvas title</h2>
+        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="offcanvas"></button>
+        </header>
+        <div class="offcanvas-body">
+        <p>Some content here</p>
+        </div>
+        </div>
+        HTML;
+
+        $this->assertEqualsHTML($expected, $html);
+    }
+
+    public function testBodyOptions(): void
+    {
+        Offcanvas::counter(0);
+
+        $html = Offcanvas::widget()->title('Offcanvas title')->bodyOptions([
+            'class' => 'custom-body-class',
+            'data-custom' => 'custom-body-data'
+        ])->begin();
+        $html .= '<p>Some content here</p>';
+        $html .= Offcanvas::end();
+
+        $expected = <<<'HTML'
+        <div id="w0-offcanvas" class="offcanvas offcanvas-start" tabindex="-1" aria-labelledby="w0-offcanvas-title">
+        <header class="offcanvas-header">
+        <h5 id="w0-offcanvas-title" class="offcanvas-title">Offcanvas title</h5>
+        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="offcanvas"></button>
+        </header>
+        <div class="custom-body-class offcanvas-body" data-custom="custom-body-data">
+        <p>Some content here</p>
+        </div>
+        </div>
+        HTML;
+
+        $this->assertEqualsHTML($expected, $html);
+    }
+
+    public function testEmptyTitle(): void
+    {
+        Offcanvas::counter(0);
+
+        $html = Offcanvas::widget()->title('')->begin();
+        $html .= '<p>Some content here</p>';
+        $html .= Offcanvas::end();
+
+        $expected = <<<'HTML'
+        <div id="w0-offcanvas" class="offcanvas offcanvas-start" tabindex="-1"">
+        <header class="offcanvas-header">
+        <h5 id="w0-offcanvas-title" class="offcanvas-title"></h5>
+        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="offcanvas"></button>
+        </header>
+        <div class="offcanvas-body">
+        <p>Some content here</p>
+        </div>
+        </div>
+        HTML;
+
+        $this->assertEqualsHTML($expected, $html);
+
+        Offcanvas::counter(0);
+
+        $html = Offcanvas::widget()->begin();
+        $html .= '<p>Some content here</p>';
+        $html .= Offcanvas::end();
+
+        $expected = <<<'HTML'
+        <div id="w0-offcanvas" class="offcanvas offcanvas-start" tabindex="-1"">
+        <header class="offcanvas-header">
+        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="offcanvas"></button>
+        </header>
+        <div class="offcanvas-body">
+        <p>Some content here</p>
+        </div>
+        </div>
+        HTML;
+
+        $this->assertEqualsHTML($expected, $html);
+    }
+
+    public function testPlacement(): void
+    {
+        $placements = [
+            Offcanvas::PLACEMENT_TOP,
+            Offcanvas::PLACEMENT_END,
+            Offcanvas::PLACEMENT_BOTTOM,
+            Offcanvas::PLACEMENT_START,
+        ];
+
+        $Offcanvas = Offcanvas::widget()->options([
+            'id' => 'offcanvas-placement'
+        ]);
+
+        foreach ($placements as $placement) {
+            $html = $Offcanvas->placement($placement)->begin() . Offcanvas::end();
+
+            $expected = <<<HTML
+            <div id="offcanvas-placement" class="offcanvas {$placement}" tabindex="-1">
+            <header class="offcanvas-header">
+            <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="offcanvas"></button>
+            </header>
+            <div class="offcanvas-body">
+            </div>
+            </div>
+            HTML;
+
+            $this->assertEqualsHTML($expected, $html);
+        }
+    }
+
+    public function testScroll(): void
+    {
+        Offcanvas::counter(0);
+
+        $html = Offcanvas::widget()->title('Offcanvas title')->scroll(true)->begin();
+        $html .= '<p>Some content here</p>';
+        $html .= Offcanvas::end();
+
+        $expected = <<<'HTML'
+        <div id="w0-offcanvas" class="offcanvas offcanvas-start" tabindex="-1" aria-labelledby="w0-offcanvas-title" data-bs-scroll="true">
+        <header class="offcanvas-header">
+        <h5 id="w0-offcanvas-title" class="offcanvas-title">Offcanvas title</h5>
+        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="offcanvas"></button>
+        </header>
+        <div class="offcanvas-body">
+        <p>Some content here</p>
+        </div>
+        </div>
+        HTML;
+
+        $this->assertEqualsHTML($expected, $html);
+    }
+
+    public function testBackdrop(): void
+    {
+        Offcanvas::counter(0);
+
+        $html = Offcanvas::widget()->title('Offcanvas title')->backdrop(false)->begin();
+        $html .= '<p>Some content here</p>';
+        $html .= Offcanvas::end();
+
+        $expected = <<<'HTML'
+        <div id="w0-offcanvas" class="offcanvas offcanvas-start" tabindex="-1" aria-labelledby="w0-offcanvas-title" data-bs-backdrop="false">
+        <header class="offcanvas-header">
+        <h5 id="w0-offcanvas-title" class="offcanvas-title">Offcanvas title</h5>
+        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="offcanvas"></button>
+        </header>
+        <div class="offcanvas-body">
+        <p>Some content here</p>
+        </div>
+        </div>
+        HTML;
+
+        $this->assertEqualsHTML($expected, $html);
+    }
+}

--- a/tests/OffcanvasTest.php
+++ b/tests/OffcanvasTest.php
@@ -165,7 +165,7 @@ final class OffcanvasTest extends TestCase
         $html .= Offcanvas::end();
 
         $expected = <<<'HTML'
-        <div id="w0-offcanvas" class="offcanvas offcanvas-start" tabindex="-1"">
+        <div id="w0-offcanvas" class="offcanvas offcanvas-start" tabindex="-1">
         <header class="offcanvas-header">
         <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="offcanvas"></button>
         </header>

--- a/tests/OffcanvasTest.php
+++ b/tests/OffcanvasTest.php
@@ -71,7 +71,7 @@ final class OffcanvasTest extends TestCase
 
         $expected = <<<'HTML'
         <div id="w0-offcanvas" class="offcanvas offcanvas-start" tabindex="-1" aria-labelledby="w0-offcanvas-title">
-        <div class="custom-class offcanvas-header" data-custom="custom-data" >
+        <div class="custom-class offcanvas-header" data-custom="custom-data">
         <h5 id="w0-offcanvas-title" class="offcanvas-title">Offcanvas title</h5>
         <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="offcanvas"></button>
         </div>
@@ -145,7 +145,7 @@ final class OffcanvasTest extends TestCase
         $html .= Offcanvas::end();
 
         $expected = <<<'HTML'
-        <div id="w0-offcanvas" class="offcanvas offcanvas-start" tabindex="-1"">
+        <div id="w0-offcanvas" class="offcanvas offcanvas-start" tabindex="-1">
         <header class="offcanvas-header">
         <h5 id="w0-offcanvas-title" class="offcanvas-title"></h5>
         <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="offcanvas"></button>

--- a/tests/OffcanvasTest.php
+++ b/tests/OffcanvasTest.php
@@ -37,7 +37,7 @@ final class OffcanvasTest extends TestCase
 
         $html = Offcanvas::widget()->options([
             'class' => 'custom-class',
-            'data-custom' => 'custom-data'
+            'data-custom' => 'custom-data',
         ])->title('Offcanvas title')->begin();
         $html .= '<p>Some content here</p>';
         $html .= Offcanvas::end();
@@ -64,7 +64,7 @@ final class OffcanvasTest extends TestCase
         $html = Offcanvas::widget()->headerOptions([
             'tag' => 'div',
             'class' => 'custom-class',
-            'data-custom' => 'custom-data'
+            'data-custom' => 'custom-data',
         ])->title('Offcanvas title')->begin();
         $html .= '<p>Some content here</p>';
         $html .= Offcanvas::end();
@@ -90,7 +90,7 @@ final class OffcanvasTest extends TestCase
 
         $html = Offcanvas::widget()->title('Offcanvas title')->titleOptions([
             'tag' => 'h2',
-            'class' => 'h4'
+            'class' => 'h4',
         ])->begin();
         $html .= '<p>Some content here</p>';
         $html .= Offcanvas::end();
@@ -116,7 +116,7 @@ final class OffcanvasTest extends TestCase
 
         $html = Offcanvas::widget()->title('Offcanvas title')->bodyOptions([
             'class' => 'custom-body-class',
-            'data-custom' => 'custom-body-data'
+            'data-custom' => 'custom-body-data',
         ])->begin();
         $html .= '<p>Some content here</p>';
         $html .= Offcanvas::end();
@@ -188,7 +188,7 @@ final class OffcanvasTest extends TestCase
         ];
 
         $Offcanvas = Offcanvas::widget()->options([
-            'id' => 'offcanvas-placement'
+            'id' => 'offcanvas-placement',
         ]);
 
         foreach ($placements as $placement) {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,6 +10,7 @@ use Yiisoft\Aliases\Aliases;
 use Yiisoft\Di\Container;
 use Yiisoft\Di\ContainerConfig;
 use Yiisoft\Widget\WidgetFactory;
+use DOMDocument;
 
 use function str_replace;
 
@@ -30,6 +31,49 @@ abstract class TestCase extends BaseTestCase
         unset($this->container);
 
         parent::tearDown();
+    }
+
+    private static function loadHtml(string $html): DOMDocument
+    {
+        $dom = new DOMDocument();
+        $dom->recover = false;
+        $dom->formatOutput = true;
+        $dom->preserveWhiteSpace = false;
+        $html = str_replace(["\r", "\n"], '', $html);
+
+        if (defined('LIBXML_NOBLANKS')) {
+            $dom->loadHtml($html, LIBXML_NOBLANKS);
+        } else {
+            $dom->loadHtml($html);
+        }
+
+        return $dom;
+    }
+
+    /**
+     * Test two strings as HTML content
+     *
+     * @param string $expected
+     * @param string $actual
+     * @param string $message
+     *
+     * @return void
+     */
+    protected function assertEqualsHTML(string $expected, string $actual, string $message = ''): void
+    {
+        libxml_use_internal_errors(true);
+        $expectedDOM = self::loadHtml($expected);
+        $actualDOM = self::loadHtml($actual);
+        $actualBody = $actualDOM->getElementsByTagName('body')->item(0);
+        $expectedBody = $expectedDOM->getElementsByTagName('body')->item(0);
+
+        $expected = $expectedDOM->saveHTML($expectedBody);
+        $actual = $actualDOM->saveHTML($actualBody);
+
+        libxml_clear_errors();
+
+        $this->assertEquals($expectedBody->childNodes->count(), $actualBody->childNodes->count());
+        $this->assertEquals($expected, $actual, $message);
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,7 +10,6 @@ use Yiisoft\Aliases\Aliases;
 use Yiisoft\Di\Container;
 use Yiisoft\Di\ContainerConfig;
 use Yiisoft\Widget\WidgetFactory;
-use DOMDocument;
 
 use function str_replace;
 
@@ -33,21 +32,13 @@ abstract class TestCase extends BaseTestCase
         parent::tearDown();
     }
 
-    private static function loadHtml(string $html): DOMDocument
+    private static function loadHtml(string $html): string
     {
-        $dom = new DOMDocument();
-        $dom->recover = false;
-        $dom->formatOutput = true;
-        $dom->preserveWhiteSpace = false;
-        $html = str_replace(["\r", "\n"], '', $html);
+        $output = str_replace(["\r", "\n"], '', $html);
+        $output = str_replace(['>', '</'], [">\n", "\n</"], $output);
+        $output = str_replace("\n\n", "\n", $output);
 
-        if (defined('LIBXML_NOBLANKS')) {
-            $dom->loadHtml($html, LIBXML_NOBLANKS);
-        } else {
-            $dom->loadHtml($html);
-        }
-
-        return $dom;
+        return trim($output);
     }
 
     /**
@@ -59,18 +50,9 @@ abstract class TestCase extends BaseTestCase
      */
     protected function assertEqualsHTML(string $expected, string $actual, string $message = ''): void
     {
-        libxml_use_internal_errors(true);
-        $expectedDOM = self::loadHtml($expected);
-        $actualDOM = self::loadHtml($actual);
-        $actualBody = $actualDOM->getElementsByTagName('body')->item(0);
-        $expectedBody = $expectedDOM->getElementsByTagName('body')->item(0);
+        $expected = self::loadHtml($expected);
+        $actual = self::loadHtml($actual);
 
-        $expected = $expectedDOM->saveHTML($expectedBody);
-        $actual = $actualDOM->saveHTML($actualBody);
-
-        libxml_clear_errors();
-
-        $this->assertEquals($expectedBody->childNodes->count(), $actualBody->childNodes->count());
         $this->assertEquals($expected, $actual, $message);
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -56,8 +56,6 @@ abstract class TestCase extends BaseTestCase
      * @param string $expected
      * @param string $actual
      * @param string $message
-     *
-     * @return void
      */
     protected function assertEqualsHTML(string $expected, string $actual, string $message = ''): void
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️

### Main 
1. Remove unimportant LE which can add additional margins from NavBar, Nav, Alert and Modal
2. New [offcanvas](https://getbootstrap.com/docs/5.1/components/offcanvas/) widget

### Nav
1. Remove not usable `encodeTags` property
2. Add `activeAttributes` method/property. With they can set some additional active link attribute like style, data-* etc

### NavBar
1. Add method/property `brandImageAttributes`
2. Add short method/property `expandSize` instead of manual pass class name and helper constant `NavBar::EXPAND_SM`, `NavBar::EXPAND_MD`, `NavBar::EXPAND_LG`, `NavBar::EXPAND_XL`, `NavBar::EXPAND_XXL`
3. Add short method/property `theme` instead of manual pass class name, helper constant `NavBar::THEME_LIGHT` and `NavBar::THEME_DARK` and short methods `dark` and `light`
4. Add `encode` option for brand and toggle button
5. Allow NavBar + Offcanvas instead of Collapse as in [demo](https://getbootstrap.com/docs/5.1/components/navbar/#offcanvas)  using new `NavBar::offcanvas` method
6. Allow [toggle external content](https://getbootstrap.com/docs/5.1/components/navbar/#external-content)

### Modal
1. Add full list of [sizes](https://getbootstrap.com/docs/5.1/components/modal/#optional-sizes) with helper constants `Modal::SIZE_SMALL`, `Modal::SIZE_DEFAULT`, `Modal::SIZE_LARGE`, `Modal::SIZE_EXTRA_LARGE`
2. Add property/method [fullscreen](https://getbootstrap.com/docs/5.1/components/modal/#fullscreen-modal) and helper constant `Modal::FULLSCREEN_ALWAYS`, `Modal::FULLSCREEN_BELOW_SM`, `Modal::FULLSCREEN_BELOW_MD`, `Modal::FULLSCREEN_BELOW_LG`, `Modal::FULLSCREEN_BELOW_XL`, `Modal::FULLSCREEN_BELOW_XXL`
3. Change close button default options as in [demo](https://getbootstrap.com/docs/5.1/components/close-button/)
4. Add separate encode option to `closeButton`, `title`, `footer`
5. Add [staticBackdrop](https://getbootstrap.com/docs/5.1/components/modal/#static-backdrop) method/property
6. Add [scrolling](https://getbootstrap.com/docs/5.1/components/modal/#scrolling-long-content) method/property
7. Add [centered](https://getbootstrap.com/docs/5.1/components/modal/#vertically-centered) method/property
8. Add [fade](https://getbootstrap.com/docs/5.1/components/modal/#remove-animation) method/property for remove animation
9. Add custom tag to `title`, `closeButton`, `toggleButton`, `footer`, `header`, `body`, `content`, `dialog`
10. Change access `renderToggleButton` method to public. That can be useful for render many toggle buttons in random page places for one modal widget
11. Allow empty title and footer. It can be useful for dynamic content using js

### Alert
1. Add new method [type](https://getbootstrap.com/docs/5.1/components/alerts/#examples), helper constant `Alert::TYPE_PRIMARY`, `Alert::TYPE_SECONDARY`, `Alert::TYPE_SUCCESS`, `Alert::TYPE_DANGER`, `Alert::TYPE_WARNING`, `Alert::TYPE_INFO`, `Alert::TYPE_LIGHT`, `Alert::TYPE_DARK` and short methods `primary`, `secondary`, `success`, `danger`, `warning`, `info`, `light`, `dark`
2. Add method/property [fade](https://getbootstrap.com/docs/5.1/components/alerts/#dismissing)
3. Add method/property [header](https://getbootstrap.com/docs/5.1/components/alerts/#additional-content) and `headerOptions`
4. Change access `renderCloseButton` method to public. It can be useful to render [outside](https://getbootstrap.com/docs/5.1/components/alerts/#triggers) close button