### PR TITLE
Small refactories

### DIFF
--- a/src/Alert.php
+++ b/src/Alert.php
@@ -31,10 +31,11 @@ final class Alert extends Widget
     private ?string $header = null;
     private array $headerOptions = [];
     private string $headerTag = 'h4';
-    private ?array $closeButton = [
+    private array $closeButton = [
         'class' => 'btn-close',
     ];
     private string $closeButtonTag = 'button';
+    private bool $closeButtonInside = true;
     private bool $encode = false;
     private array $options = [];
     private array $classNames = [];
@@ -49,13 +50,12 @@ final class Alert extends Widget
     {
         $options = $this->prepareOptions();
         $tag = ArrayHelper::remove($options, 'tag', 'div');
-        $closeButtonOutside = $this->closeButton['outside'] ?? false;
 
         $content = Html::openTag($tag, $options);
         $content .= $this->renderHeader();
         $content .= $this->encode ? Html::encode($this->body) : $this->body;
 
-        if (!$closeButtonOutside) {
+        if ($this->closeButtonInside) {
             $content .= $this->renderCloseButton(false);
         }
 
@@ -160,10 +160,10 @@ final class Alert extends Widget
      *
      * @return self
      */
-    public function withoutCloseButton(): self
+    public function withoutCloseButton(bool $value = false): self
     {
         $new = clone $this;
-        $new->closeButton = null;
+        $new->closeButtonInside = $value;
 
         return $new;
     }
@@ -334,10 +334,6 @@ final class Alert extends Widget
      */
     public function renderCloseButton(bool $outside = true): ?string
     {
-        if ($this->closeButton === null) {
-            return null;
-        }
-
         $options = array_merge(
             $this->closeButton,
             [
@@ -347,8 +343,6 @@ final class Alert extends Widget
         );
         $label = ArrayHelper::remove($options, 'label', '');
         $encode = ArrayHelper::remove($options, 'encode', $this->encode);
-
-        unset($options['outside']);
 
         if ($this->closeButtonTag === 'button' && !isset($options['type'])) {
             $options['type'] = 'button';
@@ -393,7 +387,7 @@ final class Alert extends Widget
         $options['id'] = $this->getId();
         $classNames = array_merge(['alert'], $this->classNames);
 
-        if ($this->closeButton !== null) {
+        if ($this->closeButtonInside) {
             $classNames[] = 'alert-dismissible';
         }
 

--- a/src/Offcanvas.php
+++ b/src/Offcanvas.php
@@ -18,11 +18,13 @@ final class Offcanvas extends Widget
     private array $headerOptions = [];
     private array $titleOptions = [];
     private array $bodyOptions = [];
-    private array $closeButtonOptions = [];
+    private array $closeButtonOptions = [
+        'class' => 'btn-close',
+    ];
     private ?string $title = null;
     private string $placement = self::PLACEMENT_START;
     private bool $scroll = false;
-    private bool $backdrop = true;
+    private bool $withoutBackdrop = false;
 
     public function getId(?string $suffix = '-offcanvas'): ?string
     {
@@ -36,7 +38,7 @@ final class Offcanvas extends Widget
      *
      * @link https://getbootstrap.com/docs/5.1/components/offcanvas/#backdrop
      */
-    public function scroll(bool $scroll): self
+    public function scroll(bool $scroll = true): self
     {
         $new = clone $this;
         $new->scroll = $scroll;
@@ -45,16 +47,16 @@ final class Offcanvas extends Widget
     }
 
     /**
-     * Enable/disable offcanvas
+     * Enable/disable offcanvas backdrop
      *
      * @return self
      *
      * @link https://getbootstrap.com/docs/5.1/components/offcanvas/#backdrop
      */
-    public function backdrop(bool $backdrop): self
+    public function withoutBackdrop(bool $withoutBackdrop = true): self
     {
         $new = clone $this;
-        $new->backdrop = $backdrop;
+        $new->withoutBackdrop = $withoutBackdrop;
 
         return $new;
     }
@@ -203,7 +205,7 @@ final class Offcanvas extends Widget
             $options['data-bs-scroll'] = 'true';
         }
 
-        if (!$this->backdrop) {
+        if ($this->withoutBackdrop) {
             $options['data-bs-backdrop'] = 'false';
         }
 
@@ -216,8 +218,8 @@ final class Offcanvas extends Widget
 
     protected function run(): string
     {
-        $tag = ArrayHelper::getValue($this->options, 'tag', 'div');
-        $bodyTag = ArrayHelper::getValue($this->bodyOptions, 'tag', 'div');
+        $tag = $this->options['tag'] ?? 'div';
+        $bodyTag = $this->bodyOptions['tag'] ?? 'div';
 
         return Html::closeTag($bodyTag) . Html::closeTag($tag);
     }
@@ -272,17 +274,13 @@ final class Offcanvas extends Widget
     private function renderCloseButton(): string
     {
         $options = $this->closeButtonOptions;
-        $label = ArrayHelper::remove($options, 'label');
+        $label = ArrayHelper::remove($options, 'label', '');
         $encode = ArrayHelper::remove($options, 'encode');
-
-        if ($label === null) {
-            Html::addCssClass($options, ['btn-close']);
-        }
 
         $options['type'] = 'button';
         $options['aria-label'] = 'Close';
         $options['data-bs-dismiss'] = 'offcanvas';
 
-        return Html::tag('button', $label, $options)->encode($encode)->render();
+        return Html::button($label, $options)->encode($encode)->render();
     }
 }

--- a/tests/AccordionTest.php
+++ b/tests/AccordionTest.php
@@ -69,20 +69,59 @@ final class AccordionTest extends TestCase
                         'class' => 'testClass2',
                         'id' => 'testId2',
                     ],
+                    'toggleOptions' => [
+                        'encode' => false,
+                    ],
                     'encode' => false,
                 ],
             ])
             ->render();
         $expected = <<<'HTML'
-        <div id="w0-accordion" class="accordion"><div class="accordion-item"><h2 id="w0-accordion-collapse0-heading" class="accordion-header"><button type="button" class="accordion-button" data-bs-toggle="collapse" data-bs-target="#w0-accordion-collapse0" aria-expanded="true" aria-controls="w0-accordion-collapse0">Accordion Item #1</button></h2>
-        <div id="w0-accordion-collapse0" class="accordion-collapse collapse show" aria-labelledby="w0-accordion-collapse0-heading" data-bs-parent="#w0-accordion"><div class="accordion-body">This is the first items accordion body. It is shown by default, until the collapse plugin the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can  modify any of this with custom CSS or overriding our default variables. Its also worth noting that just about any HTML can go within the .accordion-body, though the transition does limit overflow.</div></div></div>
-        <div id="testId" class="testClass accordion-item"><h2 id="w0-accordion-collapse1-heading" class="accordion-header"><button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" data-bs-target="#w0-accordion-collapse1" aria-expanded="false" aria-controls="w0-accordion-collapse1">Accordion Item #2</button></h2>
-        <div id="w0-accordion-collapse1" class="testContentOptions accordion-collapse collapse" aria-labelledby="w0-accordion-collapse1-heading" data-bs-parent="#w0-accordion"><strong>This is the second items accordion body.</strong> It is hidden by default, until the collapse plugin adds the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can modify any of this with custom CSS or overriding our default variables. Its also worth noting that just about any HTML can go within the <code>.accordion-body</code>, though the transition does limit overflow.</div></div>
-        <div id="testId2" class="testClass2 accordion-item"><h2 id="w0-accordion-collapse2-heading" class="accordion-header"><button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" data-bs-target="#w0-accordion-collapse2" aria-expanded="false" aria-controls="w0-accordion-collapse2"><b>Accordion Item #3</b></button></h2>
-        <div id="w0-accordion-collapse2" class="testContentOptions2 accordion-collapse collapse" aria-labelledby="w0-accordion-collapse2-heading" data-bs-parent="#w0-accordion"><div class="accordion-body"><b>test content1</b></div>
-        <div class="accordion-body"><strong>This is the third items accordion body.</strong> It is hidden by default, until the collapse plugin adds the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can modify any of this with custom CSS or overriding our default variables. Its also worth noting that just about any HTML can go within the <code>.accordion-body</code>, though the transition does limit overflow.</div></div></div></div>
+        <div id="w0-accordion" class="accordion">
+
+        <div class="accordion-item">
+        <h2 id="w0-accordion-collapse0-heading" class="accordion-header">
+        <button type="button" class="accordion-button" data-bs-toggle="collapse" aria-expanded="true" aria-controls="w0-accordion-collapse0" data-bs-target="#w0-accordion-collapse0">
+        Accordion Item #1
+        </button>
+        </h2>
+        <div id="w0-accordion-collapse0" class="accordion-collapse collapse show" aria-labelledby="w0-accordion-collapse0-heading" data-bs-parent="#w0-accordion">
+        <div class="accordion-body">
+        This is the first items accordion body. It is shown by default, until the collapse plugin the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can  modify any of this with custom CSS or overriding our default variables. Its also worth noting that just about any HTML can go within the .accordion-body, though the transition does limit overflow.
+        </div>
+        </div>
+        </div>
+
+        <div id="testId" class="testClass accordion-item">
+        <h2 id="w0-accordion-collapse1-heading" class="accordion-header">
+        <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-expanded="false" aria-controls="w0-accordion-collapse1" data-bs-target="#w0-accordion-collapse1">
+        Accordion Item #2
+        </button>
+        </h2>
+        <div id="w0-accordion-collapse1" class="testContentOptions accordion-collapse collapse" aria-labelledby="w0-accordion-collapse1-heading" data-bs-parent="#w0-accordion">
+        <div class="accordion-body">
+        <strong>This is the second items accordion body.</strong> It is hidden by default, until the collapse plugin adds the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can modify any of this with custom CSS or overriding our default variables. Its also worth noting that just about any HTML can go within the <code>.accordion-body</code>, though the transition does limit overflow.
+        </div>
+        </div>
+        </div>
+
+        <div id="testId2" class="testClass2 accordion-item">
+        <h2 id="w0-accordion-collapse2-heading" class="accordion-header">
+        <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-expanded="false" aria-controls="w0-accordion-collapse2" data-bs-target="#w0-accordion-collapse2">
+        <b>Accordion Item #3</b>
+        </button>
+        </h2>
+        <div id="w0-accordion-collapse2" class="testContentOptions2 accordion-collapse collapse" aria-labelledby="w0-accordion-collapse2-heading" data-bs-parent="#w0-accordion">
+        <div class="accordion-body"><b>test content1</b></div>
+        <div class="accordion-body">
+        <strong>This is the third items accordion body.</strong> It is hidden by default, until the collapse plugin adds the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can modify any of this with custom CSS or overriding our default variables. Its also worth noting that just about any HTML can go within the <code>.accordion-body</code>, though the transition does limit overflow.
+        </div>
+        </div>
+        </div>
+
+        </div>
         HTML;
-        $this->assertEqualsWithoutLE($expected, $html);
+        $this->assertEqualsHTML($expected, $html);
     }
 
     /**
@@ -139,21 +178,58 @@ final class AccordionTest extends TestCase
                         'class' => 'testClass2',
                         'id' => 'testId2',
                     ],
+                    'toggleOptions' => [
+                        'encode' => false,
+                    ],
                     'encode' => false,
                 ],
             ])
             ->flush()
             ->render();
         $expected = <<<'HTML'
-        <div id="w0-accordion" class="accordion accordion-flush"><div class="accordion-item"><h2 id="w0-accordion-collapse0-heading" class="accordion-header"><button type="button" class="accordion-button" data-bs-toggle="collapse" data-bs-target="#w0-accordion-collapse0" aria-expanded="true" aria-controls="w0-accordion-collapse0">Accordion Item #1</button></h2>
-        <div id="w0-accordion-collapse0" class="accordion-collapse collapse show" aria-labelledby="w0-accordion-collapse0-heading" data-bs-parent="#w0-accordion"><div class="accordion-body">This is the first items accordion body. It is shown by default, until the collapse plugin the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can  modify any of this with custom CSS or overriding our default variables. Its also worth noting that just about any HTML can go within the .accordion-body, though the transition does limit overflow.</div></div></div>
-        <div id="testId" class="testClass accordion-item"><h2 id="w0-accordion-collapse1-heading" class="accordion-header"><button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" data-bs-target="#w0-accordion-collapse1" aria-expanded="false" aria-controls="w0-accordion-collapse1">Accordion Item #2</button></h2>
-        <div id="w0-accordion-collapse1" class="testContentOptions accordion-collapse collapse" aria-labelledby="w0-accordion-collapse1-heading" data-bs-parent="#w0-accordion"><strong>This is the second items accordion body.</strong> It is hidden by default, until the collapse plugin adds the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can modify any of this with custom CSS or overriding our default variables. Its also worth noting that just about any HTML can go within the <code>.accordion-body</code>, though the transition does limit overflow.</div></div>
-        <div id="testId2" class="testClass2 accordion-item"><h2 id="w0-accordion-collapse2-heading" class="accordion-header"><button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" data-bs-target="#w0-accordion-collapse2" aria-expanded="false" aria-controls="w0-accordion-collapse2"><b>Accordion Item #3</b></button></h2>
-        <div id="w0-accordion-collapse2" class="testContentOptions2 accordion-collapse collapse" aria-labelledby="w0-accordion-collapse2-heading" data-bs-parent="#w0-accordion"><div class="accordion-body"><b>test content1</b></div>
-        <div class="accordion-body"><strong>This is the third items accordion body.</strong> It is hidden by default, until the collapse plugin adds the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can modify any of this with custom CSS or overriding our default variables. Its also worth noting that just about any HTML can go within the <code>.accordion-body</code>, though the transition does limit overflow.</div></div></div></div>
+        <div id="w0-accordion" class="accordion accordion-flush">
+
+        <div class="accordion-item">
+        <h2 id="w0-accordion-collapse0-heading" class="accordion-header">
+        <button type="button" class="accordion-button" data-bs-toggle="collapse" aria-expanded="true" aria-controls="w0-accordion-collapse0" data-bs-target="#w0-accordion-collapse0">Accordion Item #1</button>
+        </h2>
+        <div id="w0-accordion-collapse0" class="accordion-collapse collapse show" aria-labelledby="w0-accordion-collapse0-heading" data-bs-parent="#w0-accordion">
+        <div class="accordion-body">
+        This is the first items accordion body. It is shown by default, until the collapse plugin the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can  modify any of this with custom CSS or overriding our default variables. Its also worth noting that just about any HTML can go within the .accordion-body, though the transition does limit overflow.
+        </div>
+        </div>
+        </div>
+
+        <div id="testId" class="testClass accordion-item">
+        <h2 id="w0-accordion-collapse1-heading" class="accordion-header">
+        <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-expanded="false" aria-controls="w0-accordion-collapse1" data-bs-target="#w0-accordion-collapse1">Accordion Item #2</button>
+        </h2>
+        <div id="w0-accordion-collapse1" class="testContentOptions accordion-collapse collapse" aria-labelledby="w0-accordion-collapse1-heading" data-bs-parent="#w0-accordion">
+        <div class="accordion-body">
+        <strong>This is the second items accordion body.</strong> It is hidden by default, until the collapse plugin adds the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can modify any of this with custom CSS or overriding our default variables. Its also worth noting that just about any HTML can go within the <code>.accordion-body</code>, though the transition does limit overflow.
+        </div>
+        </div>
+        </div>
+
+        <div id="testId2" class="testClass2 accordion-item">
+        <h2 id="w0-accordion-collapse2-heading" class="accordion-header">
+        <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-expanded="false" aria-controls="w0-accordion-collapse2" data-bs-target="#w0-accordion-collapse2">
+        <b>Accordion Item #3</b>
+        </button>
+        </h2>
+        <div id="w0-accordion-collapse2" class="testContentOptions2 accordion-collapse collapse" aria-labelledby="w0-accordion-collapse2-heading" data-bs-parent="#w0-accordion">
+        <div class="accordion-body">
+        <b>test content1</b>
+        </div>
+        <div class="accordion-body">
+        <strong>This is the third items accordion body.</strong> It is hidden by default, until the collapse plugin adds the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can modify any of this with custom CSS or overriding our default variables. Its also worth noting that just about any HTML can go within the <code>.accordion-body</code>, though the transition does limit overflow.
+        </div>
+        </div>
+        </div>
+
+        </div>
         HTML;
-        $this->assertEqualsWithoutLE($expected, $html);
+        $this->assertEqualsHTML($expected, $html);
     }
 
     public function invalidItemsProvider(): array
@@ -245,12 +321,33 @@ final class AccordionTest extends TestCase
 
         $html = Accordion::widget()->items($items)->render();
         $expected = <<<'HTML'
-        <div id="w0-accordion" class="accordion"><div class="accordion-item"><h2 id="w0-accordion-collapse0-heading" class="accordion-header"><button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" data-bs-target="#w0-accordion-collapse0" aria-expanded="false" aria-controls="w0-accordion-collapse0">Item 1</button></h2>
-        <div id="w0-accordion-collapse0" class="accordion-collapse collapse" aria-labelledby="w0-accordion-collapse0-heading" data-bs-parent="#w0-accordion">Content 1</div></div>
-        <div class="accordion-item"><h2 id="w0-accordion-collapse1-heading" class="accordion-header"><button type="button" class="accordion-button" data-bs-toggle="collapse" data-bs-target="#w0-accordion-collapse1" aria-expanded="true" aria-controls="w0-accordion-collapse1">Item 2</button></h2>
-        <div id="w0-accordion-collapse1" class="accordion-collapse collapse show" aria-labelledby="w0-accordion-collapse1-heading" data-bs-parent="#w0-accordion">Content 2</div></div></div>
+        <div id="w0-accordion" class="accordion">
+
+        <div class="accordion-item">
+        <h2 id="w0-accordion-collapse0-heading" class="accordion-header">
+        <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-expanded="false" aria-controls="w0-accordion-collapse0" data-bs-target="#w0-accordion-collapse0">Item 1</button>
+        </h2>
+        <div id="w0-accordion-collapse0" class="accordion-collapse collapse" aria-labelledby="w0-accordion-collapse0-heading" data-bs-parent="#w0-accordion">
+        <div class="accordion-body">
+        Content 1
+        </div>
+        </div>
+        </div>
+
+        <div class="accordion-item">
+        <h2 id="w0-accordion-collapse1-heading" class="accordion-header">
+        <button type="button" class="accordion-button" data-bs-toggle="collapse" aria-expanded="true" aria-controls="w0-accordion-collapse1" data-bs-target="#w0-accordion-collapse1">Item 2</button>
+        </h2>
+        <div id="w0-accordion-collapse1" class="accordion-collapse collapse show" aria-labelledby="w0-accordion-collapse1-heading" data-bs-parent="#w0-accordion">
+        <div class="accordion-body">
+        Content 2
+        </div>
+        </div>
+        </div>
+
+        </div>
         HTML;
-        $this->assertEqualsWithoutLE($expected, $html);
+        $this->assertEqualsHTML($expected, $html);
     }
 
     /**
@@ -272,7 +369,6 @@ final class AccordionTest extends TestCase
         ];
 
         $html = Accordion::widget()
-
             ->items($items)
             ->itemToggleOptions([
                 'tag' => 'a',
@@ -280,7 +376,7 @@ final class AccordionTest extends TestCase
             ])
             ->render();
         $this->assertStringContainsString(
-            '<a type="button" class="custom-toggle" href="#w0-accordion-collapse0"',
+            '<a class="custom-toggle accordion-button" href="#w0-accordion-collapse0"',
             $html
         );
         $this->assertStringNotContainsString('<button', $html);
@@ -293,7 +389,7 @@ final class AccordionTest extends TestCase
             ])
             ->render();
         $this->assertStringContainsString(
-            '<a type="button" class="custom-toggle" href="#w1-accordion-collapse0"',
+            '<a class="custom-toggle accordion-button" href="#w1-accordion-collapse0"',
             $html
         );
         $this->assertStringNotContainsString('collapse-toggle', $html);
@@ -316,12 +412,33 @@ final class AccordionTest extends TestCase
 
         $html = Accordion::widget()->items($items)->options(['class' => 'testMe'])->render();
         $expected = <<<'HTML'
-        <div id="w0-accordion" class="testMe accordion"><div class="accordion-item"><h2 id="w0-accordion-collapse0-heading" class="accordion-header"><button type="button" class="accordion-button" data-bs-toggle="collapse" data-bs-target="#w0-accordion-collapse0" aria-expanded="true" aria-controls="w0-accordion-collapse0">Item 1</button></h2>
-        <div id="w0-accordion-collapse0" class="accordion-collapse collapse show" aria-labelledby="w0-accordion-collapse0-heading" data-bs-parent="#w0-accordion">Content 1</div></div>
-        <div class="accordion-item"><h2 id="w0-accordion-collapse1-heading" class="accordion-header"><button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" data-bs-target="#w0-accordion-collapse1" aria-expanded="false" aria-controls="w0-accordion-collapse1">Item 2</button></h2>
-        <div id="w0-accordion-collapse1" class="accordion-collapse collapse" aria-labelledby="w0-accordion-collapse1-heading" data-bs-parent="#w0-accordion">Content 2</div></div></div>
+        <div id="w0-accordion" class="testMe accordion">
+
+        <div class="accordion-item">
+        <h2 id="w0-accordion-collapse0-heading" class="accordion-header">
+        <button type="button" class="accordion-button" data-bs-toggle="collapse" aria-expanded="true" aria-controls="w0-accordion-collapse0" data-bs-target="#w0-accordion-collapse0">Item 1</button>
+        </h2>
+        <div id="w0-accordion-collapse0" class="accordion-collapse collapse show" aria-labelledby="w0-accordion-collapse0-heading" data-bs-parent="#w0-accordion">
+        <div class="accordion-body">
+        Content 1
+        </div>
+        </div>
+        </div>
+
+        <div class="accordion-item">
+        <h2 id="w0-accordion-collapse1-heading" class="accordion-header">
+        <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-expanded="false" aria-controls="w0-accordion-collapse1" data-bs-target="#w0-accordion-collapse1">Item 2</button>
+        </h2>
+        <div id="w0-accordion-collapse1" class="accordion-collapse collapse" aria-labelledby="w0-accordion-collapse1-heading" data-bs-parent="#w0-accordion">
+        <div class="accordion-body">
+        Content 2
+        </div>
+        </div>
+        </div>
+
+        </div>
         HTML;
-        $this->assertEqualsWithoutLE($expected, $html);
+        $this->assertEqualsHTML($expected, $html);
     }
 
     public function testEncodeLabels(): void
@@ -341,21 +458,63 @@ final class AccordionTest extends TestCase
 
         $html = Accordion::widget()->items($items)->render();
         $expected = <<<'HTML'
-        <div id="w0-accordion" class="accordion"><div class="accordion-item"><h2 id="w0-accordion-collapse0-heading" class="accordion-header"><button type="button" class="accordion-button" data-bs-toggle="collapse" data-bs-target="#w0-accordion-collapse0" aria-expanded="true" aria-controls="w0-accordion-collapse0">Item 1</button></h2>
-        <div id="w0-accordion-collapse0" class="accordion-collapse collapse show" aria-labelledby="w0-accordion-collapse0-heading" data-bs-parent="#w0-accordion">Content 1</div></div>
-        <div class="accordion-item"><h2 id="w0-accordion-collapse1-heading" class="accordion-header"><button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" data-bs-target="#w0-accordion-collapse1" aria-expanded="false" aria-controls="w0-accordion-collapse1">&lt;span&gt;&lt;i class="fas fa-eye"&gt;Item 2&lt;/i&gt;&lt;/span&gt;</button></h2>
-        <div id="w0-accordion-collapse1" class="accordion-collapse collapse" aria-labelledby="w0-accordion-collapse1-heading" data-bs-parent="#w0-accordion">Content 2</div></div></div>
+        <div id="w0-accordion" class="accordion">
+
+        <div class="accordion-item">
+        <h2 id="w0-accordion-collapse0-heading" class="accordion-header">
+        <button type="button" class="accordion-button" data-bs-toggle="collapse" aria-expanded="true" aria-controls="w0-accordion-collapse0" data-bs-target="#w0-accordion-collapse0">Item 1</button>
+        </h2>
+        <div id="w0-accordion-collapse0" class="accordion-collapse collapse show" aria-labelledby="w0-accordion-collapse0-heading" data-bs-parent="#w0-accordion">
+        <div class="accordion-body">
+        Content 1
+        </div>
+        </div>
+        </div>
+
+        <div class="accordion-item">
+        <h2 id="w0-accordion-collapse1-heading" class="accordion-header">
+        <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-expanded="false" aria-controls="w0-accordion-collapse1" data-bs-target="#w0-accordion-collapse1">&lt;span&gt;&lt;i class="fas fa-eye"&gt;Item 2&lt;/i&gt;&lt;/span&gt;</button>
+        </h2>
+        <div id="w0-accordion-collapse1" class="accordion-collapse collapse" aria-labelledby="w0-accordion-collapse1-heading" data-bs-parent="#w0-accordion">
+        <div class="accordion-body">
+        Content 2
+        </div>
+        </div>
+        </div>
+
+        </div>
         HTML;
-        $this->assertEqualsWithoutLE($expected, $html);
+        $this->assertEqualsHTML($expected, $html);
 
         $html = Accordion::widget()->items($items)->withoutEncodeLabels()->render();
         $expected = <<<'HTML'
-        <div id="w1-accordion" class="accordion"><div class="accordion-item"><h2 id="w1-accordion-collapse0-heading" class="accordion-header"><button type="button" class="accordion-button" data-bs-toggle="collapse" data-bs-target="#w1-accordion-collapse0" aria-expanded="true" aria-controls="w1-accordion-collapse0">Item 1</button></h2>
-        <div id="w1-accordion-collapse0" class="accordion-collapse collapse show" aria-labelledby="w1-accordion-collapse0-heading" data-bs-parent="#w1-accordion">Content 1</div></div>
-        <div class="accordion-item"><h2 id="w1-accordion-collapse1-heading" class="accordion-header"><button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" data-bs-target="#w1-accordion-collapse1" aria-expanded="false" aria-controls="w1-accordion-collapse1"><span><i class="fas fa-eye">Item 2</i></span></button></h2>
-        <div id="w1-accordion-collapse1" class="accordion-collapse collapse" aria-labelledby="w1-accordion-collapse1-heading" data-bs-parent="#w1-accordion">Content 2</div></div></div>
+        <div id="w1-accordion" class="accordion">
+
+        <div class="accordion-item">
+        <h2 id="w1-accordion-collapse0-heading" class="accordion-header">
+        <button type="button" class="accordion-button" data-bs-toggle="collapse" aria-expanded="true" aria-controls="w1-accordion-collapse0" data-bs-target="#w1-accordion-collapse0">Item 1</button>
+        </h2>
+        <div id="w1-accordion-collapse0" class="accordion-collapse collapse show" aria-labelledby="w1-accordion-collapse0-heading" data-bs-parent="#w1-accordion">
+        <div class="accordion-body">
+        Content 1
+        </div>
+        </div>
+        </div>
+
+        <div class="accordion-item">
+        <h2 id="w1-accordion-collapse1-heading" class="accordion-header">
+        <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-expanded="false" aria-controls="w1-accordion-collapse1" data-bs-target="#w1-accordion-collapse1"><span><i class="fas fa-eye">Item 2</i></span></button>
+        </h2>
+        <div id="w1-accordion-collapse1" class="accordion-collapse collapse" aria-labelledby="w1-accordion-collapse1-heading" data-bs-parent="#w1-accordion">
+        <div class="accordion-body">
+        Content 2
+        </div>
+        </div>
+        </div>
+
+        </div>
         HTML;
-        $this->assertEqualsWithoutLE($expected, $html);
+        $this->assertEqualsHTML($expected, $html);
     }
 
     public function testAllClose(): void
@@ -377,12 +536,33 @@ final class AccordionTest extends TestCase
 
         $html = Accordion::widget()->items($items)->render();
         $expected = <<<'HTML'
-        <div id="w0-accordion" class="accordion"><div class="accordion-item"><h2 id="w0-accordion-collapse0-heading" class="accordion-header"><button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" data-bs-target="#w0-accordion-collapse0" aria-expanded="false" aria-controls="w0-accordion-collapse0">Item 1</button></h2>
-        <div id="w0-accordion-collapse0" class="accordion-collapse collapse" aria-labelledby="w0-accordion-collapse0-heading" data-bs-parent="#w0-accordion">Content 1</div></div>
-        <div class="accordion-item"><h2 id="w0-accordion-collapse1-heading" class="accordion-header"><button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" data-bs-target="#w0-accordion-collapse1" aria-expanded="false" aria-controls="w0-accordion-collapse1">Item 2</button></h2>
-        <div id="w0-accordion-collapse1" class="accordion-collapse collapse" aria-labelledby="w0-accordion-collapse1-heading" data-bs-parent="#w0-accordion">Content 2</div></div></div>
+        <div id="w0-accordion" class="accordion">
+
+        <div class="accordion-item">
+        <h2 id="w0-accordion-collapse0-heading" class="accordion-header">
+        <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-expanded="false" aria-controls="w0-accordion-collapse0" data-bs-target="#w0-accordion-collapse0">Item 1</button>
+        </h2>
+        <div id="w0-accordion-collapse0" class="accordion-collapse collapse" aria-labelledby="w0-accordion-collapse0-heading" data-bs-parent="#w0-accordion">
+        <div class="accordion-body">
+        Content 1
+        </div>
+        </div>
+        </div>
+
+        <div class="accordion-item">
+        <h2 id="w0-accordion-collapse1-heading" class="accordion-header">
+        <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-expanded="false" aria-controls="w0-accordion-collapse1" data-bs-target="#w0-accordion-collapse1">Item 2</button>
+        </h2>
+        <div id="w0-accordion-collapse1" class="accordion-collapse collapse" aria-labelledby="w0-accordion-collapse1-heading" data-bs-parent="#w0-accordion">
+        <div class="accordion-body">
+        Content 2
+        </div>
+        </div>
+        </div>
+
+        </div>
         HTML;
-        $this->assertEqualsWithoutLE($expected, $html);
+        $this->assertEqualsHTML($expected, $html);
 
 
         Accordion::counter(0);
@@ -400,11 +580,32 @@ final class AccordionTest extends TestCase
 
         $html = Accordion::widget()->items($items)->defaultExpand(false)->render();
         $expected = <<<'HTML'
-        <div id="w0-accordion" class="accordion"><div class="accordion-item"><h2 id="w0-accordion-collapse0-heading" class="accordion-header"><button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" data-bs-target="#w0-accordion-collapse0" aria-expanded="false" aria-controls="w0-accordion-collapse0">Item 1</button></h2>
-        <div id="w0-accordion-collapse0" class="accordion-collapse collapse" aria-labelledby="w0-accordion-collapse0-heading" data-bs-parent="#w0-accordion">Content 1</div></div>
-        <div class="accordion-item"><h2 id="w0-accordion-collapse1-heading" class="accordion-header"><button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" data-bs-target="#w0-accordion-collapse1" aria-expanded="false" aria-controls="w0-accordion-collapse1">Item 2</button></h2>
-        <div id="w0-accordion-collapse1" class="accordion-collapse collapse" aria-labelledby="w0-accordion-collapse1-heading" data-bs-parent="#w0-accordion">Content 2</div></div></div>
+        <div id="w0-accordion" class="accordion">
+
+        <div class="accordion-item">
+        <h2 id="w0-accordion-collapse0-heading" class="accordion-header">
+        <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-expanded="false" aria-controls="w0-accordion-collapse0" data-bs-target="#w0-accordion-collapse0">Item 1</button>
+        </h2>
+        <div id="w0-accordion-collapse0" class="accordion-collapse collapse" aria-labelledby="w0-accordion-collapse0-heading" data-bs-parent="#w0-accordion">
+        <div class="accordion-body">
+        Content 1
+        </div>
+        </div>
+        </div>
+
+        <div class="accordion-item">
+        <h2 id="w0-accordion-collapse1-heading" class="accordion-header">
+        <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-expanded="false" aria-controls="w0-accordion-collapse1" data-bs-target="#w0-accordion-collapse1">Item 2</button>
+        </h2>
+        <div id="w0-accordion-collapse1" class="accordion-collapse collapse" aria-labelledby="w0-accordion-collapse1-heading" data-bs-parent="#w0-accordion">
+        <div class="accordion-body">
+        Content 2
+        </div>
+        </div>
+        </div>
+
+        </div>
         HTML;
-        $this->assertEqualsWithoutLE($expected, $html);
+        $this->assertEqualsHTML($expected, $html);
     }
 }

--- a/tests/OffcanvasTest.php
+++ b/tests/OffcanvasTest.php
@@ -235,7 +235,7 @@ final class OffcanvasTest extends TestCase
     {
         Offcanvas::counter(0);
 
-        $html = Offcanvas::widget()->title('Offcanvas title')->backdrop(false)->begin();
+        $html = Offcanvas::widget()->title('Offcanvas title')->withoutBackdrop()->begin();
         $html .= '<p>Some content here</p>';
         $html .= Offcanvas::end();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    |  ❌
| New feature?  | ❌
| Breaks BC?    | ✔️

1. Split `Accordion::renderItems` to separate small methods `renderItem`, `renderHeader`, `renderToggle`, `renderCollapse`, `renderBody` for easier support
2. All contents wrapped with `accordion-body`
3. Small refactoring `Offcanvas` and `Alert`
