### PR TITLE
Set psalm error level to 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,9 +61,7 @@
         "sort-packages": true,
         "allow-plugins": {
             "infection/extension-installer": true,
-            "composer/package-versions-deprecated": true,
-            "composer/installers": true,
-            "oomphinc/composer-installers-extender": true
+            "composer/package-versions-deprecated": true
         }
     },
     "repositories": [

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "oomphinc/composer-installers-extender": "^2.0.0",
         "yiisoft/arrays": "^1.0|^2.0",
         "yiisoft/assets": "^2.0",
-        "yiisoft/html": "^2.0",
+        "yiisoft/html": "^2.5",
         "yiisoft/json": "^1.0",
         "yiisoft/widget": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,9 @@
         "sort-packages": true,
         "allow-plugins": {
             "infection/extension-installer": true,
-            "composer/package-versions-deprecated": true
+            "composer/package-versions-deprecated": true,
+            "composer/installers": true,
+            "oomphinc/composer-installers-extender": true
         }
     },
     "repositories": [

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    errorLevel="3"
+    errorLevel="2"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    errorLevel="4"
+    errorLevel="3"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"

--- a/src/Accordion.php
+++ b/src/Accordion.php
@@ -504,6 +504,10 @@ final class Accordion extends Widget
             ->render();
     }
 
+    /**
+     * @param mixed $value
+     * @return bool
+     */
     private function isStringableObject($value): bool
     {
         return is_object($value) && method_exists($value, '__toString');

--- a/src/Accordion.php
+++ b/src/Accordion.php
@@ -351,7 +351,6 @@ final class Accordion extends Widget
     /**
      * Renders a single collapsible item group.
      *
-     * @param string $label a label of the item group {@see items}
      * @param array $item a single item from {@see items}
      * @param int $index the item index as each item group content must have an id
      *
@@ -496,7 +495,7 @@ final class Accordion extends Widget
                 throw new RuntimeException('The "content" option should be a string, array or object.');
             }
 
-            $items .= (string) $value;
+            $items .= $value;
         }
 
         return Html::div($items, ['class' => 'accordion-body'])

--- a/src/Alert.php
+++ b/src/Alert.php
@@ -161,6 +161,7 @@ final class Alert extends Widget
     /**
      * Disable close button.
      *
+     * @param bool $value
      * @return self
      */
     public function withoutCloseButton(bool $value = false): self
@@ -237,7 +238,7 @@ final class Alert extends Widget
     /**
      * Set type of alert, 'alert-success', 'alert-danger', 'custom-alert' etc
      *
-     * @param string $type
+     * @param string ...$classNames
      *
      * @return self
      */

--- a/src/Alert.php
+++ b/src/Alert.php
@@ -30,10 +30,12 @@ final class Alert extends Widget
     private string $body = '';
     private ?string $header = null;
     private array $headerOptions = [];
+    /** @psalm-var non-empty-string */
     private string $headerTag = 'h4';
     private array $closeButton = [
         'class' => 'btn-close',
     ];
+    /** @psalm-var non-empty-string */
     private string $closeButtonTag = 'button';
     private bool $closeButtonInside = true;
     private bool $encode = false;
@@ -116,6 +118,7 @@ final class Alert extends Widget
      * Set tag name for header
      *
      * @param string $tag
+     * @psalm-param non-empty-string $tag
      *
      * @return self
      */
@@ -172,6 +175,7 @@ final class Alert extends Widget
      * Set close button tag
      *
      * @param string $tag
+     * @psalm-param non-empty-string $tag
      *
      * @return self
      */

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -26,6 +26,7 @@ use function strtr;
  */
 final class Breadcrumbs extends Widget
 {
+    /** @psalm-var non-empty-string */
     private string $tag = 'ol';
     private bool $encodeLabels = true;
     private bool $encodeTags = false;
@@ -201,6 +202,7 @@ final class Breadcrumbs extends Widget
      * The name of the breadcrumb container tag.
      *
      * @param string $value
+     * @psalm-param non-empty-string $value
      *
      * @return self
      */

--- a/src/Button.php
+++ b/src/Button.php
@@ -19,6 +19,7 @@ use Yiisoft\Html\Html;
  */
 final class Button extends Widget
 {
+    /** @psalm-var non-empty-string */
     private string $tagName = 'button';
     private string $label = 'Button';
     private bool $encodeLabels = true;
@@ -92,6 +93,7 @@ final class Button extends Widget
      * The tag to use to render the button.
      *
      * @param string $value
+     * @psalm-param non-empty-string $value
      *
      * @return self
      */

--- a/src/ButtonDropdown.php
+++ b/src/ButtonDropdown.php
@@ -53,6 +53,7 @@ final class ButtonDropdown extends Widget
     private array $dropdown = [];
     private string $direction = self::DIRECTION_DOWN;
     private bool $split = false;
+    /** @psalm-var non-empty-string */
     private string $tagName = 'button';
     private bool $encodeLabels = true;
     private bool $encodeTags = false;
@@ -240,6 +241,7 @@ final class ButtonDropdown extends Widget
      * The tag to use to render the button.
      *
      * @param string $value
+     * @psalm-param non-empty-string $value
      *
      * @return self
      */

--- a/src/ButtonDropdown.php
+++ b/src/ButtonDropdown.php
@@ -57,6 +57,7 @@ final class ButtonDropdown extends Widget
     private string $tagName = 'button';
     private bool $encodeLabels = true;
     private bool $encodeTags = false;
+    /** @psalm-var class-string */
     private string $dropdownClass = Dropdown::class;
     private bool $renderContainer = true;
 
@@ -154,6 +155,7 @@ final class ButtonDropdown extends Widget
      * Name of a class to use for rendering dropdowns withing this widget. Defaults to {@see Dropdown}.
      *
      * @param string $value
+     * @psalm-param class-string $value
      *
      * @return self
      */

--- a/src/ButtonDropdown.php
+++ b/src/ButtonDropdown.php
@@ -272,9 +272,9 @@ final class ButtonDropdown extends Widget
             $label = Html::encode($label);
         }
 
-        if ($this->split) {
-            $buttonOptions = $this->buttonOptions;
+        $buttonOptions = $this->buttonOptions;
 
+        if ($this->split) {
             $this->buttonOptions['data-bs-toggle'] = 'dropdown';
             $this->buttonOptions['aria-haspopup'] = 'true';
             $this->buttonOptions['aria-expanded'] = 'false';
@@ -289,8 +289,6 @@ final class ButtonDropdown extends Widget
                 ->withoutEncodeLabels()
                 ->render();
         } else {
-            $buttonOptions = $this->buttonOptions;
-
             Html::addCssClass($buttonOptions, ['toggle' => 'dropdown-toggle']);
 
             $buttonOptions['data-bs-toggle'] = 'dropdown';

--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -194,7 +194,7 @@ final class Dropdown extends Widget
 
         return Html::ul()
             ->items(...$lines)
-            ->attributes($options)
+            ->addAttributes($options)
             ->render();
     }
 
@@ -245,7 +245,7 @@ final class Dropdown extends Widget
 
             return Li::tag()
                 ->content($content)
-                ->attributes($itemOptions)
+                ->addAttributes($itemOptions)
                 ->encode(false);
         }
 
@@ -282,7 +282,7 @@ final class Dropdown extends Widget
 
         return Li::tag()
             ->content($toggle . $dropdown->render())
-            ->attributes($itemOptions)
+            ->addAttributes($itemOptions)
             ->encode(false);
     }
 }

--- a/src/Modal.php
+++ b/src/Modal.php
@@ -235,7 +235,7 @@ final class Modal extends Widget
      * The rest of the options will be rendered as the HTML attributes of the button tag. Please refer to the
      * [Modal plugin help](http://getbootstrap.com/javascript/#modals) for the supported HTML attributes.
      *
-     * @param array $value
+     * @param array|null $value
      *
      * @return self
      */
@@ -260,7 +260,7 @@ final class Modal extends Widget
     /**
      * The footer content in the modal window.
      *
-     * @param string $value
+     * @param string|null $value
      *
      * @return self
      */
@@ -325,7 +325,7 @@ final class Modal extends Widget
     /**
      * The title content in the modal window.
      *
-     * @param string $value
+     * @param string|null $value
      *
      * @return self
      */
@@ -368,7 +368,7 @@ final class Modal extends Widget
      * The rest of the options will be rendered as the HTML attributes of the button tag. Please refer to the
      * [Modal plugin help](http://getbootstrap.com/javascript/#modals) for the supported HTML attributes.
      *
-     * @param array $value
+     * @param array|null $value
      *
      * @return self
      */
@@ -393,7 +393,7 @@ final class Modal extends Widget
     /**
      * The modal size. Can be {@see SIZE_LARGE} or {@see SIZE_SMALL}, or null for default.
      *
-     * @param string $value
+     * @param string|null $value
      *
      * @return self
      *
@@ -640,12 +640,8 @@ final class Modal extends Widget
         if (!isset($options['data-bs-target'])) {
             $target = (string) $this->getId();
 
-            if ($tag === 'a') {
-                if (!isset($options['href'])) {
-                    $options['href'] = '#' . $target;
-                } else {
-                    $options['data-bs-target'] = '#' . $target;
-                }
+            if ($tag === 'a' && !isset($options['href'])) {
+                $options['href'] = '#' . $target;
             } else {
                 $options['data-bs-target'] = '#' . $target;
             }

--- a/src/Modal.php
+++ b/src/Modal.php
@@ -625,7 +625,7 @@ final class Modal extends Widget
             [
                 'data-bs-toggle' => 'modal',
             ],
-            $this->toggleButton,
+            $this->toggleButton ?? [],
             $options
         );
 

--- a/src/Nav.php
+++ b/src/Nav.php
@@ -106,6 +106,7 @@ final class Nav extends Widget
     private bool $activateParents = false;
     private ?string $activeClass = null;
     private string $currentPath = '';
+    /** @psalm-var class-string  */
     private string $dropdownClass = Dropdown::class;
     private array $options = [];
     private array $itemOptions = [];
@@ -232,6 +233,7 @@ final class Nav extends Widget
      * Name of a class to use for rendering dropdowns within this widget. Defaults to {@see Dropdown}.
      *
      * @param string $value
+     * @psalm-param class-string $value
      *
      * @return self
      */

--- a/src/NavBar.php
+++ b/src/NavBar.php
@@ -500,7 +500,7 @@ final class NavBar extends Widget
 
         if (!empty($this->brandImage)) {
             $encode = false;
-            $content = Html::img($this->brandImage)->attributes($this->brandImageAttributes);
+            $content = Html::img($this->brandImage)->addAttributes($this->brandImageAttributes);
         }
 
         if (!empty($this->brandText)) {

--- a/src/NavBar.php
+++ b/src/NavBar.php
@@ -180,7 +180,8 @@ final class NavBar extends Widget
         $htmlStart .= $this->renderBrand();
 
         if ($offcanvas) {
-            $htmlStart .= $this->renderToggleButton($this->offcanvas->getId());
+            $offcanvasId = $this->offcanvas ? $this->offcanvas->getId() : null;
+            $htmlStart .= $this->renderToggleButton($offcanvasId);
             $htmlStart .= $offcanvas;
         } elseif ($this->expandSize) {
             $collapseOptions = $this->collapseOptions;

--- a/src/Tabs.php
+++ b/src/Tabs.php
@@ -373,7 +373,7 @@ final class Tabs extends Widget
      * Renders tab items as specified on {@see items}.
      *
      * @param array $items
-     * @param string $navId
+     * @param string|null $navId
      * @param string $prefix
      *
      * @throws JsonException|RuntimeException

--- a/src/Tabs.php
+++ b/src/Tabs.php
@@ -54,6 +54,7 @@ use function array_merge;
  *         ],
  *     ]);
  * ```
+ * @psalm-suppress MissingConstructor
  */
 final class Tabs extends Widget
 {
@@ -212,7 +213,7 @@ final class Tabs extends Widget
      * {@see Html::renderTagAttributes()} for details on how attributes are being rendered.
      * {@see Nav::linkOptions()}
      *
-     * @param array $options
+     * @param array $value
      *
      * @return self
      */
@@ -225,7 +226,7 @@ final class Tabs extends Widget
      * List of HTML attributes for the item container tags. This will be overwritten by the "options" set in individual
      * {@see items}. The following special options are recognized.
      *
-     * @param array $value
+     * @param array $options
      *
      * @return self
      *
@@ -332,7 +333,7 @@ final class Tabs extends Widget
     /**
      * Prepare Nav::widget for using
      *
-     * @param array $options
+     * @param array $definitions
      * @param array $items
      *
      * @return Nav


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -

- Set psalm error level to 2
- Replace deprecated `attributes()` with `addAttributes()`