### PR TITLE
Dropdown improvements

### DIFF
--- a/src/Button.php
+++ b/src/Button.php
@@ -32,6 +32,10 @@ final class Button extends Widget
             $this->options['id'] = "{$this->getId()}-button";
         }
 
+        if ($this->theme) {
+            $this->options['data-bs-theme'] = $this->theme;
+        }
+
         /** @psalm-suppress InvalidArgument */
         Html::addCssClass($this->options, ['widget' => 'btn']);
 

--- a/src/ButtonDropdown.php
+++ b/src/ButtonDropdown.php
@@ -18,7 +18,7 @@ use Yiisoft\Html\Html;
  * // a button group using Dropdown widget
  * echo ButtonDropdown::widget()
  *     ->label('Action')
- *     ->items'([
+ *     ->items([
 *             ['label' => 'DropdownA', 'url' => '/'],
 *             ['label' => 'DropdownB', 'url' => '#'],
  *     ]);

--- a/src/ButtonDropdown.php
+++ b/src/ButtonDropdown.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Yii\Bootstrap5;
 
+use Stringable;
 use Yiisoft\Arrays\ArrayHelper;
 use Yiisoft\Definitions\Exception\InvalidConfigException;
 use Yiisoft\Html\Html;
@@ -17,11 +18,9 @@ use Yiisoft\Html\Html;
  * // a button group using Dropdown widget
  * echo ButtonDropdown::widget()
  *     ->label('Action')
- *     ->dropdown'([
- *         'items' => [
- *             ['label' => 'DropdownA', 'url' => '/'],
- *             ['label' => 'DropdownB', 'url' => '#'],
- *         ],
+ *     ->items'([
+*             ['label' => 'DropdownA', 'url' => '/'],
+*             ['label' => 'DropdownB', 'url' => '#'],
  *     ]);
  * ```
  */
@@ -48,47 +47,49 @@ final class ButtonDropdown extends Widget
     public const DIRECTION_UP = 'up';
 
     private string $label = 'Button';
+    private ?array $labelOptions = null;
     private array $options = [];
     private array $buttonOptions = [];
-    private array $dropdown = [];
+    private array|string|Stringable $items = [];
     private string $direction = self::DIRECTION_DOWN;
     private bool $split = false;
     /** @psalm-var non-empty-string */
     private string $tagName = 'button';
     private bool $encodeLabels = true;
     private bool $encodeTags = false;
-    /** @psalm-var class-string */
-    private string $dropdownClass = Dropdown::class;
+    /** @psalm-var class-string|Dropdown */
+    private string|Dropdown $dropdownClass = Dropdown::class;
     private bool $renderContainer = true;
+
+    public function getId(?string $suffix = '-button-dropdown'): ?string
+    {
+        return $this->options['id'] ?? parent::getId($suffix);
+    }
 
     public function render(): string
     {
-        if (!isset($this->dropdown['items'])) {
+        if (empty($this->items)) {
             return '';
         }
 
-        /** Set options id to button options id to ensure correct css selector in plugin initialisation */
-        if (empty($this->options['id'])) {
-            $id = $this->getId();
-
-            $this->options['id'] = "{$id}-button-dropdown";
-            $this->buttonOptions['id'] = "{$id}-button";
-        }
-
-        $html = $this->renderButton() . "\n" . $this->renderDropdown();
-
         if ($this->renderContainer) {
-            /** @psalm-suppress InvalidArgument */
-            Html::addCssClass($this->options, ['widget' => 'drop' . $this->direction, 'btn-group']);
-
             $options = $this->options;
+            $options['id'] = $this->getId();
+
+            /** @psalm-suppress InvalidArgument */
+            Html::addCssClass($options, ['widget' => 'drop' . $this->direction, 'btn-group']);
+
+            if ($this->theme) {
+                $options['data-bs-theme'] = $this->theme;
+            }
+
             $tag = ArrayHelper::remove($options, 'tag', 'div');
-            $html = Html::tag($tag, $html, $options)
+            return Html::tag($tag, $this->renderButton() . "\n" . $this->renderDropdown(), $options)
                 ->encode($this->encodeTags)
                 ->render();
         }
 
-        return $html;
+        return $this->renderButton() . "\n" . $this->renderDropdown();
     }
 
     /**
@@ -122,19 +123,17 @@ final class ButtonDropdown extends Widget
      *
      * ```php
      *    [
-     *        'items' => [
      *            ['label' => 'DropdownA', 'url' => '/'],
      *            ['label' => 'DropdownB', 'url' => '#'],
-     *        ],
      *    ]
      * ```
      *
      * {@see Dropdown}
      */
-    public function dropdown(array $value): self
+    public function items(array|string|Stringable $value): self
     {
         $new = clone $this;
-        $new->dropdown = $value;
+        $new->items = $value;
 
         return $new;
     }
@@ -144,7 +143,7 @@ final class ButtonDropdown extends Widget
      *
      * @psalm-param class-string $value
      */
-    public function dropdownClass(string $value): self
+    public function dropdownClass(string|Dropdown $value): self
     {
         $new = clone $this;
         $new->dropdownClass = $value;
@@ -170,6 +169,14 @@ final class ButtonDropdown extends Widget
     {
         $new = clone $this;
         $new->label = $value;
+
+        return $new;
+    }
+
+    public function withLabelOptions(?array $options): self
+    {
+        $new = clone $this;
+        $new->labelOptions = $options;
 
         return $new;
     }
@@ -223,6 +230,31 @@ final class ButtonDropdown extends Widget
         return $new;
     }
 
+    private function prepareButtonOptions(bool $toggle): array
+    {
+        $options = $this->buttonOptions;
+        $classNames = ['button' => 'btn'];
+
+        if ($toggle) {
+            $options['data-bs-toggle'] = 'dropdown';
+            $options['aria-haspopup'] = 'true';
+            $options['aria-expanded'] = 'false';
+            $classNames['toggle'] = 'dropdown-toggle';
+        }
+
+        Html::addCssClass($options, $classNames);
+
+        if ($this->tagName !== 'button') {
+            $options['role'] = 'button';
+
+            if ($this->tagName === 'a' && !isset($options['href'])) {
+                $options['href'] = '#';
+            }
+        }
+
+        return $options;
+    }
+
     /**
      * Generates the button dropdown.
      *
@@ -232,47 +264,12 @@ final class ButtonDropdown extends Widget
      */
     private function renderButton(): string
     {
-        Html::addCssClass($this->buttonOptions, ['buttonOptions' => 'btn']);
-
-        $label = $this->label;
-
-        if ($this->encodeLabels !== false) {
-            $label = Html::encode($label);
-        }
-
-        $buttonOptions = $this->buttonOptions;
-
-        if ($this->split) {
-            $this->buttonOptions['data-bs-toggle'] = 'dropdown';
-            $this->buttonOptions['aria-haspopup'] = 'true';
-            $this->buttonOptions['aria-expanded'] = 'false';
-
-            Html::addCssClass($this->buttonOptions, ['toggle' => 'dropdown-toggle dropdown-toggle-split']);
-
-            unset($buttonOptions['id']);
-
-            $splitButton = Button::widget()
-                ->label('<span class="sr-only">Toggle Dropdown</span>')
-                ->options($this->buttonOptions)
-                ->withoutEncodeLabels()
-                ->render();
-        } else {
-            Html::addCssClass($buttonOptions, ['toggle' => 'dropdown-toggle']);
-
-            $buttonOptions['data-bs-toggle'] = 'dropdown';
-            $buttonOptions['aria-haspopup'] = 'true';
-            $buttonOptions['aria-expanded'] = 'false';
-            $splitButton = '';
-        }
-
-        if (!isset($buttonOptions['href']) && ($this->tagName === 'a')) {
-            $buttonOptions['href'] = '#';
-            $buttonOptions['role'] = 'button';
-        }
-
+        $splitButton = $this->renderSplitButton();
+        $options = $this->prepareButtonOptions($splitButton === null);
         $button = Button::widget()
-            ->label($label)
-            ->options($buttonOptions)
+            ->options($options)
+            ->label($this->renderLabel())
+            ->withTheme($this->renderContainer ? null : $this->theme)
             ->tagName($this->tagName);
 
         if ($this->encodeLabels === false) {
@@ -282,16 +279,61 @@ final class ButtonDropdown extends Widget
         return $button->render() . "\n" . $splitButton;
     }
 
+    private function renderSplitButton(): ?string
+    {
+        if ($this->split === false) {
+            return null;
+        }
+
+        $options = $this->prepareButtonOptions(true);
+        Html::addCssClass($options, 'dropdown-toggle-split');
+
+        return Button::widget()
+            ->options($options)
+            ->label('<span class="visually-hidden">Toggle Dropdown</span>')
+            ->tagName($this->tagName)
+            ->withoutEncodeLabels()
+            ->withTheme($this->renderContainer ? null : $this->theme)
+            ->render();
+    }
+
+    private function renderLabel(): string
+    {
+        if ($this->labelOptions === null) {
+            return $this->encodeLabels ? Html::encode($this->label) : $this->label;
+        }
+
+        $options = $this->labelOptions;
+        $tag = ArrayHelper::remove($options, 'tag', 'span');
+        $encode = ArrayHelper::remove($options, 'encode', $this->encodeLabels);
+
+        return Html::tag($tag, $this->label, $options)
+            ->encode($encode)
+            ->render();
+    }
+
     /**
      * Generates the dropdown menu.
      *
-     * @return string the rendering result.
+     * @return string
+     * @throws InvalidConfigException
+     * @throws \Yiisoft\Definitions\Exception\CircularReferenceException
+     * @throws \Yiisoft\Definitions\Exception\NotInstantiableException
+     * @throws \Yiisoft\Factory\NotFoundException
      */
     private function renderDropdown(): string
     {
-        $dropdownClass = $this->dropdownClass;
+        if (is_string($this->dropdownClass)) {
+            $dropdownClass = $this->dropdownClass;
+            /** @var Dropdown $dropdownClass */
+            $dropdown = $dropdownClass::widget()->items($this->items);
+        } else {
+            $dropdown = $this->dropdownClass->items($this->items);
+        }
 
-        $dropdown = $dropdownClass::widget()->items($this->dropdown['items']);
+        if ($this->theme && !$this->renderContainer) {
+            $dropdown = $dropdown->withTheme($this->theme);
+        }
 
         if ($this->encodeLabels === false) {
             $dropdown = $dropdown->withoutEncodeLabels();

--- a/src/NavBar.php
+++ b/src/NavBar.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Yiisoft\Yii\Bootstrap5;
 
-use Stringable;
 use JsonException;
+use Stringable;
 use Yiisoft\Arrays\ArrayHelper;
 use Yiisoft\Html\Html;
 
@@ -120,9 +120,6 @@ final class NavBar extends Widget
     public const EXPAND_XL = 'navbar-expand-xl';
     public const EXPAND_XXL = 'navbar-expand-xxl';
 
-    public const THEME_LIGHT = 'navbar-light';
-    public const THEME_DARK = 'navbar-dark';
-
     private array $collapseOptions = [];
     private ?string $brandText = null;
     private ?string $brandImage = null;
@@ -137,7 +134,6 @@ final class NavBar extends Widget
     private array $options = [];
     private bool $encodeTags = false;
     private ?string $expandSize = self::EXPAND_LG;
-    private ?string $theme = self::THEME_LIGHT;
     private ?Offcanvas $offcanvas = null;
 
     public function getId(?string $suffix = '-navbar'): ?string
@@ -162,7 +158,13 @@ final class NavBar extends Widget
         }
 
         if ($this->theme) {
-            $classNames['theme'] = $this->theme;
+            $options['data-bs-theme'] = $this->theme;
+
+            if ($this->theme === self::THEME_DARK) {
+                $classNames['theme'] = 'navbar-dark';
+            } elseif ($this->theme === self::THEME_LIGHT) {
+                $classNames['theme'] = 'navbar-light';
+            }
         }
 
         Html::addCssClass($options, $classNames);
@@ -233,33 +235,6 @@ final class NavBar extends Widget
         $new->expandSize = $size;
 
         return $new;
-    }
-
-    /**
-     * Set color theme for NavBar
-     */
-    public function theme(?string $theme): self
-    {
-        $new = clone $this;
-        $new->theme = $theme;
-
-        return $new;
-    }
-
-    /**
-     * Short method for light navbar theme
-     */
-    public function light(): self
-    {
-        return $this->theme(self::THEME_LIGHT);
-    }
-
-    /**
-     * Short method for dark navbar theme
-     */
-    public function dark(): self
-    {
-        return $this->theme(self::THEME_DARK);
     }
 
     /**

--- a/src/Offcanvas.php
+++ b/src/Offcanvas.php
@@ -177,6 +177,10 @@ final class Offcanvas extends Widget
             $options['data-bs-backdrop'] = 'false';
         }
 
+        if ($this->theme) {
+            $options['data-bs-theme'] = $this->theme;
+        }
+
         $html = Html::openTag($tag, $options);
         $html .= $this->renderHeader();
         $html .= Html::openTag($bodyTag, $bodyOptions);

--- a/src/Widget.php
+++ b/src/Widget.php
@@ -4,12 +4,19 @@ declare(strict_types=1);
 
 namespace Yiisoft\Yii\Bootstrap5;
 
-abstract class Widget extends \Yiisoft\Widget\Widget
+use Yiisoft\Widget\Widget as YiiWidget;
+
+abstract class Widget extends YiiWidget
 {
+    public const THEME_DARK = 'dark';
+    public const THEME_LIGHT = 'light';
+
     private ?string $id = null;
     private bool $autoGenerate = true;
     private string $autoIdPrefix = 'w';
     private static int $counter = 0;
+    protected ?string $theme = null;
+
 
     /**
      * Returns the ID of the widget.
@@ -30,9 +37,9 @@ abstract class Widget extends \Yiisoft\Widget\Widget
     /**
      * Set the ID of the widget.
      *
-     * @return self
+     * @return static
      */
-    public function id(string $value): self
+    public function id(string $value): static
     {
         $new = clone $this;
         $new->id = $value;
@@ -51,14 +58,32 @@ abstract class Widget extends \Yiisoft\Widget\Widget
     /**
      * The prefix to the automatically generated widget IDs.
      *
-     * @return self
+     * @return static
      * {@see getId()}
      */
-    public function autoIdPrefix(string $value): self
+    public function autoIdPrefix(string $value): static
     {
         $new = clone $this;
         $new->autoIdPrefix = $value;
 
         return $new;
+    }
+
+    public function withTheme(?string $theme): static
+    {
+        $new = clone $this;
+        $new->theme = $theme;
+
+        return $new;
+    }
+
+    public function withDarkTheme(): static
+    {
+        return $this->withTheme(self::THEME_DARK);
+    }
+
+    public function withLightTheme(): static
+    {
+        return $this->withTheme(self::THEME_LIGHT);
     }
 }

--- a/tests/ButtonDropdownTest.php
+++ b/tests/ButtonDropdownTest.php
@@ -19,12 +19,12 @@ final class ButtonDropdownTest extends TestCase
         ButtonDropdown::counter(0);
 
         $html = ButtonDropdown::widget()
-            ->dropdown(['items' => [['label' => 'ItemA', 'url' => '#'], ['label' => 'ItemB', 'url' => '#']]])
+            ->items([['label' => 'ItemA', 'url' => '#'], ['label' => 'ItemB', 'url' => '#']])
             ->render();
         $expected = <<<'HTML'
-        <div id="w0-button-dropdown" class="dropdown btn-group"><button id="w0-button" class="btn dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Button</button>
+        <div id="w0-button-dropdown" class="dropdown btn-group"><button id="w1-button" class="btn dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Button</button>
 
-        <ul id="w1-dropdown" class="dropdown-menu" aria-expanded="false">
+        <ul id="w2-dropdown" class="dropdown-menu">
         <li><a class="dropdown-item" href="#">ItemA</a></li>
         <li><a class="dropdown-item" href="#">ItemB</a></li>
         </ul></div>
@@ -45,17 +45,15 @@ final class ButtonDropdownTest extends TestCase
         $html = ButtonDropdown::widget()
             ->direction(ButtonDropdown::DIRECTION_LEFT)
             ->label('Action')
-            ->dropdown([
-                'items' => [
-                    ['label' => 'ItemA', 'url' => '#'],
-                    ['label' => 'ItemB', 'url' => '#'],
-                ],
+            ->items([
+                ['label' => 'ItemA', 'url' => '#'],
+                ['label' => 'ItemB', 'url' => '#'],
             ])
             ->render();
         $expected = <<<'HTML'
-        <div id="w0-button-dropdown" class="dropleft btn-group"><button id="w0-button" class="btn dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Action</button>
+        <div id="w0-button-dropdown" class="dropleft btn-group"><button id="w1-button" class="btn dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Action</button>
 
-        <ul id="w1-dropdown" class="dropdown-menu" aria-expanded="false">
+        <ul id="w2-dropdown" class="dropdown-menu">
         <li><a class="dropdown-item" href="#">ItemA</a></li>
         <li><a class="dropdown-item" href="#">ItemB</a></li>
         </ul></div>
@@ -71,17 +69,15 @@ final class ButtonDropdownTest extends TestCase
             ->direction(ButtonDropdown::DIRECTION_DOWN)
             ->label('Split dropdown')
             ->split()
-            ->dropdown([
-                'items' => [
-                    ['label' => 'ItemA', 'url' => '#'],
-                    ['label' => 'ItemB', 'url' => '#'],
-                ],
+            ->items([
+                ['label' => 'ItemA', 'url' => '#'],
+                ['label' => 'ItemB', 'url' => '#'],
             ])
             ->render();
         $expected = <<<'HTML'
-        <div id="w0-button-dropdown" class="dropdown btn-group"><button id="w1-button" class="btn">Split dropdown</button>
-        <button id="w0-button" class="btn dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><span class="sr-only">Toggle Dropdown</span></button>
-        <ul id="w2-dropdown" class="dropdown-menu" aria-expanded="false">
+        <div id="w0-button-dropdown" class="dropdown btn-group"><button id="w2-button" class="btn">Split dropdown</button>
+        <button id="w1-button" class="btn dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><span class="visually-hidden">Toggle Dropdown</span></button>
+        <ul id="w3-dropdown" class="dropdown-menu">
         <li><a class="dropdown-item" href="#">ItemA</a></li>
         <li><a class="dropdown-item" href="#">ItemB</a></li>
         </ul></div>
@@ -94,18 +90,16 @@ final class ButtonDropdownTest extends TestCase
         ButtonDropdown::counter(0);
 
         $html = ButtonDropdown::widget()
-            ->dropdown([
-                'items' => [
-                    ['label' => 'ItemA', 'url' => '#'],
-                    ['label' => 'ItemB', 'url' => '#'],
-                ],
+            ->items([
+                ['label' => 'ItemA', 'url' => '#'],
+                ['label' => 'ItemB', 'url' => '#'],
             ])
             ->buttonOptions(['class' => 'btn-lg'])
             ->render();
         $expected = <<<'HTML'
-        <div id="w0-button-dropdown" class="dropdown btn-group"><button id="w0-button" class="btn-lg btn dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Button</button>
+        <div id="w0-button-dropdown" class="dropdown btn-group"><button id="w1-button" class="btn-lg btn dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Button</button>
 
-        <ul id="w1-dropdown" class="dropdown-menu" aria-expanded="false">
+        <ul id="w2-dropdown" class="dropdown-menu">
         <li><a class="dropdown-item" href="#">ItemA</a></li>
         <li><a class="dropdown-item" href="#">ItemB</a></li>
         </ul></div>
@@ -118,18 +112,16 @@ final class ButtonDropdownTest extends TestCase
         ButtonDropdown::counter(0);
 
         $html = ButtonDropdown::widget()
-            ->dropdown([
-                'items' => [
-                    ['label' => 'ItemA', 'url' => '#'],
-                    ['label' => 'ItemB', 'url' => '#'],
-                ],
+            ->items([
+                ['label' => 'ItemA', 'url' => '#'],
+                ['label' => 'ItemB', 'url' => '#'],
             ])
             ->dropdownClass(Dropdown::class)
             ->render();
         $expected = <<<'HTML'
-        <div id="w0-button-dropdown" class="dropdown btn-group"><button id="w0-button" class="btn dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Button</button>
+        <div id="w0-button-dropdown" class="dropdown btn-group"><button id="w1-button" class="btn dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Button</button>
 
-        <ul id="w1-dropdown" class="dropdown-menu" aria-expanded="false">
+        <ul id="w2-dropdown" class="dropdown-menu">
         <li><a class="dropdown-item" href="#">ItemA</a></li>
         <li><a class="dropdown-item" href="#">ItemB</a></li>
         </ul></div>
@@ -142,19 +134,17 @@ final class ButtonDropdownTest extends TestCase
         ButtonDropdown::counter(0);
 
         $html = ButtonDropdown::widget()
-            ->dropdown(
+            ->items(
                 [
-                    'items' => [
-                        ['label' => 'ItemA', 'url' => '#'],
-                        ['label' => '<span><i class=fas fas-tests>ItemB></i></span>', 'url' => '#'],
-                    ],
+                    ['label' => 'ItemA', 'url' => '#'],
+                    ['label' => '<span><i class=fas fas-tests>ItemB></i></span>', 'url' => '#'],
                 ]
             )
             ->render();
         $expected = <<<'HTML'
-        <div id="w0-button-dropdown" class="dropdown btn-group"><button id="w0-button" class="btn dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Button</button>
+        <div id="w0-button-dropdown" class="dropdown btn-group"><button id="w1-button" class="btn dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Button</button>
 
-        <ul id="w1-dropdown" class="dropdown-menu" aria-expanded="false">
+        <ul id="w2-dropdown" class="dropdown-menu">
         <li><a class="dropdown-item" href="#">ItemA</a></li>
         <li><a class="dropdown-item" href="#">&lt;span&gt;&lt;i class=fas fas-tests&gt;ItemB&gt;&lt;/i&gt;&lt;/span&gt;</a></li>
         </ul></div>
@@ -162,20 +152,18 @@ final class ButtonDropdownTest extends TestCase
         $this->assertEqualsWithoutLE($expected, $html);
 
         $html = ButtonDropdown::widget()
-            ->dropdown(
+            ->items(
                 [
-                    'items' => [
-                        ['label' => 'ItemA', 'url' => '#'],
-                        ['label' => '<span><i class=fas fas-tests>ItemB></i></span>', 'url' => '#'],
-                    ],
+                    ['label' => 'ItemA', 'url' => '#'],
+                    ['label' => '<span><i class=fas fas-tests>ItemB></i></span>', 'url' => '#'],
                 ]
             )
             ->withoutEncodeLabels()
             ->render();
         $expected = <<<'HTML'
-        <div id="w2-button-dropdown" class="dropdown btn-group"><button id="w2-button" class="btn dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Button</button>
+        <div id="w3-button-dropdown" class="dropdown btn-group"><button id="w4-button" class="btn dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Button</button>
 
-        <ul id="w3-dropdown" class="dropdown-menu" aria-expanded="false">
+        <ul id="w5-dropdown" class="dropdown-menu">
         <li><a class="dropdown-item" href="#">ItemA</a></li>
         <li><a class="dropdown-item" href="#"><span><i class=fas fas-tests>ItemB></i></span></a></li>
         </ul></div>
@@ -188,13 +176,13 @@ final class ButtonDropdownTest extends TestCase
         ButtonDropdown::counter(0);
 
         $html = ButtonDropdown::widget()
-            ->dropdown(['items' => [['label' => 'ItemA', 'url' => '#'], ['label' => 'ItemB', 'url' => '#']]])
+            ->items([['label' => 'ItemA', 'url' => '#'], ['label' => 'ItemB', 'url' => '#']])
             ->options(['class' => 'testMe'])
             ->render();
         $expected = <<<'HTML'
-        <div id="w0-button-dropdown" class="testMe dropdown btn-group"><button id="w0-button" class="btn dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Button</button>
+        <div id="w0-button-dropdown" class="testMe dropdown btn-group"><button id="w1-button" class="btn dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Button</button>
 
-        <ul id="w1-dropdown" class="dropdown-menu" aria-expanded="false">
+        <ul id="w2-dropdown" class="dropdown-menu">
         <li><a class="dropdown-item" href="#">ItemA</a></li>
         <li><a class="dropdown-item" href="#">ItemB</a></li>
         </ul></div>
@@ -207,13 +195,13 @@ final class ButtonDropdownTest extends TestCase
         ButtonDropdown::counter(0);
 
         $html = ButtonDropdown::widget()
-            ->dropdown(['items' => [['label' => 'ItemA', 'url' => '#'], ['label' => 'ItemB', 'url' => '#']]])
+            ->items([['label' => 'ItemA', 'url' => '#'], ['label' => 'ItemB', 'url' => '#']])
             ->withoutRenderContainer()
             ->render();
         $expected = <<<'HTML'
         <button id="w0-button" class="btn dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Button</button>
 
-        <ul id="w1-dropdown" class="dropdown-menu" aria-expanded="false">
+        <ul id="w1-dropdown" class="dropdown-menu">
         <li><a class="dropdown-item" href="#">ItemA</a></li>
         <li><a class="dropdown-item" href="#">ItemB</a></li>
         </ul>
@@ -226,18 +214,102 @@ final class ButtonDropdownTest extends TestCase
         ButtonDropdown::counter(0);
 
         $html = ButtonDropdown::widget()
-            ->dropdown(['items' => [['label' => 'ItemA', 'url' => '#'], ['label' => 'ItemB']]])
+            ->items([['label' => 'ItemA', 'url' => '#'], ['label' => 'ItemB']])
             ->tagName('a')
             ->render();
 
         $expected = <<<'HTML'
-        <div id="w0-button-dropdown" class="dropdown btn-group"><a id="w0-button" class="btn dropdown-toggle" href="#" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" role="button">Button</a>
+        <div id="w0-button-dropdown" class="dropdown btn-group"><a id="w1-button" class="btn dropdown-toggle" href="#" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" role="button">Button</a>
 
-        <ul id="w1-dropdown" class="dropdown-menu" aria-expanded="false">
+        <ul id="w2-dropdown" class="dropdown-menu">
         <li><a class="dropdown-item" href="#">ItemA</a></li>
         <li><h6 class="dropdown-header">ItemB</h6></li>
         </ul></div>
         HTML;
         $this->assertEqualsWithoutLE($expected, $html);
+    }
+
+    public function testLabelOptions(): void
+    {
+        ButtonDropdown::counter(0);
+
+        $html = ButtonDropdown::widget()
+            ->items([['label' => 'ItemA', 'url' => '#'], ['label' => 'ItemB']])
+            ->label('Custom label')
+            ->withLabelOptions([
+                'class' => 'd-none d-lg-inline-block',
+            ])
+            ->withoutEncodeLabels()
+            ->render();
+
+        $expected = <<<'HTML'
+        <div id="w0-button-dropdown" class="dropdown btn-group"><button id="w1-button" class="btn dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><span class="d-none d-lg-inline-block">Custom label</span></button>
+
+        <ul id="w2-dropdown" class="dropdown-menu">
+        <li><a class="dropdown-item" href="#">ItemA</a></li>
+        <li><h6 class="dropdown-header">ItemB</h6></li>
+        </ul></div>
+        HTML;
+        $this->assertEqualsWithoutLE($expected, $html);
+    }
+
+    public function testCustomDropdown(): void
+    {
+        $dropdown = Dropdown::widget()
+            ->withAlignment(Dropdown::ALIGNMENT_END);
+
+        ButtonDropdown::counter(0);
+
+        $html = ButtonDropdown::widget()
+            ->items([['label' => 'ItemA', 'url' => '#'], ['label' => 'ItemB']])
+            ->dropdownClass($dropdown)
+            ->render();
+
+        $expected = <<<'HTML'
+        <div id="w0-button-dropdown" class="dropdown btn-group"><button id="w1-button" class="btn dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Button</button>
+
+        <ul id="w2-dropdown" class="dropdown-menu dropdown-menu-end">
+        <li><a class="dropdown-item" href="#">ItemA</a></li>
+        <li><h6 class="dropdown-header">ItemB</h6></li>
+        </ul></div>
+        HTML;
+        $this->assertEqualsWithoutLE($expected, $html);
+    }
+
+    public function testTheme(): void
+    {
+        ButtonDropdown::counter(0);
+
+        $html = ButtonDropdown::widget()
+            ->items([['label' => 'ItemA', 'url' => '#'], ['label' => 'ItemB', 'url' => '#']])
+            ->withoutRenderContainer()
+            ->withDarkTheme()
+            ->render();
+        $expected = <<<'HTML'
+        <button id="w0-button" class="btn dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" data-bs-theme="dark">Button</button>
+
+        <ul id="w1-dropdown" class="dropdown-menu dropdown-menu-dark" data-bs-theme="dark">
+        <li><a class="dropdown-item" href="#">ItemA</a></li>
+        <li><a class="dropdown-item" href="#">ItemB</a></li>
+        </ul>
+        HTML;
+        $this->assertEqualsWithoutLE($expected, $html);
+
+        ButtonDropdown::counter(0);
+
+        $html = ButtonDropdown::widget()
+            ->items([['label' => 'ItemA', 'url' => '#'], ['label' => 'ItemB', 'url' => '#']])
+            ->withLightTheme()
+            ->render();
+        $expected = <<<'HTML'
+        <div id="w0-button-dropdown" class="dropdown btn-group" data-bs-theme="light"><button id="w1-button" class="btn dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Button</button>
+
+        <ul id="w2-dropdown" class="dropdown-menu">
+        <li><a class="dropdown-item" href="#">ItemA</a></li>
+        <li><a class="dropdown-item" href="#">ItemB</a></li>
+        </ul></div>
+        HTML;
+        $this->assertEqualsWithoutLE($expected, $html);
+
     }
 }

--- a/tests/DropdownTest.php
+++ b/tests/DropdownTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Yiisoft\Yii\Bootstrap5\Tests;
 
 use RuntimeException;
+use Yiisoft\Html\Html;
 use Yiisoft\Yii\Bootstrap5\Dropdown;
 
 /**
@@ -49,15 +50,131 @@ final class DropdownTest extends TestCase
             ])
             ->render();
         $expected = <<<'HTML'
-        <ul id="w0-dropdown" class="dropdown-menu" aria-expanded="false">
+        <ul id="w0-dropdown" class="dropdown-menu">
         <li><a class="dropdown-item disabled" href="#" tabindex="-1" aria-disabled="true">Page1</a></li>
         <li><a class="dropdown-item active" href="#">Page2</a></li>
-        <li class="dropdown" aria-expanded="false"><a class="dropdown-item dropdown-toggle" href="#test" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-haspopup="true" aria-expanded="false" role="button">Dropdown1</a><ul id="w1-dropdown" class="dropdown-menu" aria-expanded="false">
+        <li class="dropdown" aria-expanded="false"><a class="dropdown-item dropdown-toggle" href="#test" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-haspopup="true" aria-expanded="false" role="button">Dropdown1</a><ul id="w1-dropdown" class="dropdown-menu">
         <li><h6 class="dropdown-header">Page2</h6></li>
         <li><h6 class="dropdown-header">Page3</h6></li>
         </ul></li>
         </ul>
         HTML;
+        $this->assertEqualsWithoutLE($expected, $html);
+    }
+
+    public function testRenderString(): void
+    {
+        Dropdown::counter(0);
+
+        $html = Dropdown::widget()
+            ->items('Some string content')
+            ->render();
+
+        $expected = '<div id="w0-dropdown" class="dropdown-menu">Some string content</div>';
+
+        $this->assertEqualsWithoutLE($expected, $html);
+    }
+
+    public function testRenderStringableContent(): void
+    {
+        Dropdown::counter(0);
+
+        $html = Dropdown::widget()
+            ->items(Html::p('Some stringable p-tag content'))
+            ->render();
+
+        $expected = <<<'HTML'
+        <div id="w0-dropdown" class="dropdown-menu"><p>Some stringable p-tag content</p></div>
+        HTML;
+
+        $this->assertEqualsWithoutLE($expected, $html);
+    }
+
+    public function testAlignment(): void
+    {
+        Dropdown::counter(0);
+
+        $html = Dropdown::widget()
+            ->items('I\'m alignment end dropdown')
+            ->withAlignment(Dropdown::ALIGNMENT_END)
+            ->render();
+
+        $expected = <<<'HTML'
+        <div id="w0-dropdown" class="dropdown-menu dropdown-menu-end">I'm alignment end dropdown</div>
+        HTML;
+
+        $this->assertEqualsWithoutLE($expected, $html);
+
+        Dropdown::counter(0);
+
+        $html = Dropdown::widget()
+            ->items('I\'m alignment end, but xl start dropdown')
+            ->withAlignment(Dropdown::ALIGNMENT_END, Dropdown::ALIGNMENT_XL_START)
+            ->render();
+
+        $expected = <<<'HTML'
+        <div id="w0-dropdown" class="dropdown-menu dropdown-menu-end dropdown-menu-xl-start">I'm alignment end, but xl start dropdown</div>
+        HTML;
+
+        $this->assertEqualsWithoutLE($expected, $html);
+    }
+
+    public function testOuterContent(): void
+    {
+        Dropdown::counter(0);
+
+        $html = Dropdown::widget()
+            ->items(null)
+            ->begin();
+        $html .= 'I\'m very-very-very-very long content';
+        $html .= Dropdown::end();
+
+        $expected = <<<'HTML'
+        <div id="w0-dropdown" class="dropdown-menu">I'm very-very-very-very long content</div>
+        HTML;
+
+        $this->assertEqualsWithoutLE($expected, $html);
+    }
+
+    public function testTheme(): void
+    {
+        Dropdown::counter(0);
+
+        $html = Dropdown::widget()
+            ->items('I\'m dark dropdown')
+            ->withDarkTheme()
+            ->render();
+
+        $expected = <<<'HTML'
+        <div id="w0-dropdown" class="dropdown-menu dropdown-menu-dark" data-bs-theme="dark">I'm dark dropdown</div>
+        HTML;
+
+        $this->assertEqualsWithoutLE($expected, $html);
+
+        Dropdown::counter(0);
+
+        $html = Dropdown::widget()
+            ->items('I\'m light dropdown')
+            ->withLightTheme()
+            ->render();
+
+        $expected = <<<'HTML'
+        <div id="w0-dropdown" class="dropdown-menu" data-bs-theme="light">I'm light dropdown</div>
+        HTML;
+
+        $this->assertEqualsWithoutLE($expected, $html);
+
+        Dropdown::counter(0);
+
+        $html = Dropdown::widget()
+            ->items('I\'m blue dropdown')
+            ->withTheme('blue')
+            ->render();
+
+        $expected = <<<'HTML'
+        <div id="w0-dropdown" class="dropdown-menu" data-bs-theme="blue">I'm blue dropdown</div>
+        HTML;
+
         $this->assertEqualsWithoutLE($expected, $html);
     }
 
@@ -97,13 +214,13 @@ final class DropdownTest extends TestCase
             ->submenuOptions(['class' => 'submenu-list'])
             ->render();
         $expected = <<<'HTML'
-        <ul id="w0-dropdown" class="dropdown-menu" aria-expanded="false">
-        <li class="dropdown" aria-expanded="false"><a class="dropdown-item dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-haspopup="true" aria-expanded="false" role="button">Dropdown1</a><ul id="w1-dropdown" class="submenu-list dropdown-menu" aria-expanded="false">
+        <ul id="w0-dropdown" class="dropdown-menu">
+        <li class="dropdown" aria-expanded="false"><a class="dropdown-item dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-haspopup="true" aria-expanded="false" role="button">Dropdown1</a><ul id="w1-dropdown" class="submenu-list dropdown-menu">
         <li><h6 class="dropdown-header">Page1</h6></li>
         <li><h6 class="dropdown-header">Page2</h6></li>
         </ul></li>
         <li><hr class="dropdown-divider"></li>
-        <li class="dropdown" aria-expanded="false"><a class="dropdown-item dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-haspopup="true" aria-expanded="false" role="button">Dropdown2</a><ul id="w2-dropdown" class="submenu-override dropdown-menu" aria-expanded="false">
+        <li class="dropdown" aria-expanded="false"><a class="dropdown-item dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-haspopup="true" aria-expanded="false" role="button">Dropdown2</a><ul id="w2-dropdown" class="submenu-override dropdown-menu">
         <li><h6 class="dropdown-header">Page3</h6></li>
         <li><h6 class="dropdown-header">Page4</h6></li>
         </ul></li>
@@ -146,7 +263,7 @@ final class DropdownTest extends TestCase
             ])
             ->render();
         $expected = <<<'HTML'
-        <ul id="w0-dropdown" class="dropdown-menu" aria-expanded="false">
+        <ul id="w0-dropdown" class="dropdown-menu">
         <li><form class="px-4 py-3">
         <div class="form-group">
         <label for="exampleDropdownFormEmail1">Email address</label>
@@ -173,6 +290,23 @@ final class DropdownTest extends TestCase
         $this->assertEqualsWithoutLE($expected, $html);
     }
 
+    public function testEncodeTags(): void
+    {
+        Dropdown::counter(0);
+
+        $html = Dropdown::widget()
+            ->items(Html::p('Some stringable p-tag content'))
+            ->withEncodeTags(true)
+            ->render();
+
+        $expected = <<<'HTML'
+        <div id="w0-dropdown" class="dropdown-menu">&lt;p&gt;Some stringable p-tag content&lt;/p&gt;</div>
+        HTML;
+
+        $this->assertEqualsWithoutLE($expected, $html);
+
+    }
+
     public function testEncodeLabels(): void
     {
         Dropdown::counter(0);
@@ -189,8 +323,8 @@ final class DropdownTest extends TestCase
             ])
             ->render();
         $expected = <<<'HTML'
-        <ul id="w0-dropdown" class="dropdown-menu" aria-expanded="false">
-        <li class="dropdown" aria-expanded="false"><a class="dropdown-item dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-haspopup="true" aria-expanded="false" role="button">&lt;span&gt;&lt;i class=fas fastest&gt;&lt;/i&gt;Dropdown1&lt;/span&gt;</a><ul id="w1-dropdown" class="dropdown-menu" aria-expanded="false">
+        <ul id="w0-dropdown" class="dropdown-menu">
+        <li class="dropdown" aria-expanded="false"><a class="dropdown-item dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-haspopup="true" aria-expanded="false" role="button">&lt;span&gt;&lt;i class=fas fastest&gt;&lt;/i&gt;Dropdown1&lt;/span&gt;</a><ul id="w1-dropdown" class="dropdown-menu">
         <li><h6 class="dropdown-header">Page1</h6></li>
         <li><h6 class="dropdown-header">Page2</h6></li>
         </ul></li>
@@ -211,8 +345,8 @@ final class DropdownTest extends TestCase
             ])
             ->render();
         $expected = <<<'HTML'
-        <ul id="w2-dropdown" class="dropdown-menu" aria-expanded="false">
-        <li class="dropdown" aria-expanded="false"><a class="dropdown-item dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-haspopup="true" aria-expanded="false" role="button"><span><i class=fas fastest></i>Dropdown1</span></a><ul id="w3-dropdown" class="dropdown-menu" aria-expanded="false">
+        <ul id="w2-dropdown" class="dropdown-menu">
+        <li class="dropdown" aria-expanded="false"><a class="dropdown-item dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-haspopup="true" aria-expanded="false" role="button"><span><i class=fas fastest></i>Dropdown1</span></a><ul id="w3-dropdown" class="dropdown-menu">
         <li><h6 class="dropdown-header">Page1</h6></li>
         <li><h6 class="dropdown-header">Page2</h6></li>
         </ul></li>
@@ -253,7 +387,7 @@ final class DropdownTest extends TestCase
             ->render();
 
         $expected = <<<'HTML'
-        <ul id="w0-dropdown" class="dropdown-menu" aria-expanded="false">
+        <ul id="w0-dropdown" class="dropdown-menu">
         <li class="main-item-class"><a class="main-link-class dropdown-item" href="#">Label 1</a></li>
         <li id="custom-item-id" class="custom-item-class"><a class="custom-link-class dropdown-item" href="#">Label 2</a></li>
         </ul>

--- a/tests/NavBarTest.php
+++ b/tests/NavBarTest.php
@@ -22,7 +22,7 @@ final class NavBarTest extends TestCase
         $html = NavBar::widget()
             ->brandText('My Company')
             ->brandUrl('/')
-            ->theme(null)
+            ->withTheme(null)
             ->options([
                 'class' => 'navbar-inverse navbar-static-top navbar-frontend',
             ])
@@ -137,14 +137,14 @@ final class NavBarTest extends TestCase
 
         $html .= NavBar::end();
         $expected = <<<'HTML'
-        <nav id="w0-navbar" class="navbar navbar-expand-lg navbar-light">
+        <nav id="w0-navbar" class="navbar navbar-expand-lg">
         <div class="container">
         <a class="navbar-brand" href="/">My Company</a>
         <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-navbar-collapse" aria-controls="w0-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
         <div id="w0-navbar-collapse" class="collapse navbar-collapse">
         <ul id="w1-nav" class="mr-auto nav"><li class="nav-item"><a class="nav-link" href="#">Home</a></li>
         <li class="nav-item"><a class="nav-link" href="#">Link</a></li>
-        <li class="dropdown nav-item"><a class="dropdown-toggle nav-link" href="#" data-bs-toggle="dropdown">Dropdown</a><ul id="w2-dropdown" class="dropdown-menu" aria-expanded="false">
+        <li class="dropdown nav-item"><a class="dropdown-toggle nav-link" href="#" data-bs-toggle="dropdown">Dropdown</a><ul id="w2-dropdown" class="dropdown-menu">
         <li><a class="dropdown-item" href="#">Action</a></li>
         <li><a class="dropdown-item" href="#">Another action</a></li>
         <li><hr class="dropdown-divider"></li>
@@ -168,7 +168,7 @@ final class NavBarTest extends TestCase
             ->begin();
         $html .= NavBar::end();
         $expected = <<<'HTML'
-        <nav id="w0-navbar" class="navbar navbar-expand-lg navbar-light">
+        <nav id="w0-navbar" class="navbar navbar-expand-lg">
         <div class="container">
 
         <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-navbar-collapse" aria-controls="w0-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
@@ -190,7 +190,7 @@ final class NavBarTest extends TestCase
             ->begin();
         $html .= NavBar::end();
         $expected = <<<'HTML'
-        <nav id="w0-navbar" class="navbar navbar-expand-lg navbar-light">
+        <nav id="w0-navbar" class="navbar navbar-expand-lg">
         <div class="container">
         <a class="text-dark navbar-brand" href="/">My App</a>
         <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-navbar-collapse" aria-controls="w0-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
@@ -212,7 +212,7 @@ final class NavBarTest extends TestCase
             ->begin();
         $html .= NavBar::end();
         $expected = <<<'HTML'
-        <nav id="w0-navbar" class="navbar navbar-expand-lg navbar-light">
+        <nav id="w0-navbar" class="navbar navbar-expand-lg">
         <div class="container">
         <a class="navbar-brand" href="/"><img src="empty.gif" width="100" height="100" alt></a>
         <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-navbar-collapse" aria-controls="w0-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
@@ -233,7 +233,7 @@ final class NavBarTest extends TestCase
             ->begin();
         $html .= NavBar::end();
         $expected = <<<'HTML'
-        <nav id="w0-navbar" class="navbar navbar-expand-lg navbar-light">
+        <nav id="w0-navbar" class="navbar navbar-expand-lg">
         <div class="container">
 
         <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-navbar-collapse" aria-controls="w0-navbar-collapse" aria-expanded="false" aria-label="Toggler navigation"><span class="navbar-toggler-icon"></span></button>
@@ -254,7 +254,7 @@ final class NavBarTest extends TestCase
             ->begin();
         $html .= NavBar::end();
         $expected = <<<'HTML'
-        <nav id="w0-navbar" class="navbar navbar-expand-lg navbar-light">
+        <nav id="w0-navbar" class="navbar navbar-expand-lg">
         <div class="container">
 
         <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-navbar-collapse" aria-controls="w0-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><div class="navbar-toggler-icon"></div></button>
@@ -275,7 +275,7 @@ final class NavBarTest extends TestCase
             ->begin();
         $html .= NavBar::end();
         $expected = <<<'HTML'
-        <nav id="w0-navbar" class="navbar navbar-expand-lg navbar-light">
+        <nav id="w0-navbar" class="navbar navbar-expand-lg">
         <div class="container">
 
         <button type="button" class="testMe navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-navbar-collapse" aria-controls="w0-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
@@ -296,7 +296,7 @@ final class NavBarTest extends TestCase
             ->begin();
         $html .= NavBar::end();
         $expected = <<<'HTML'
-        <nav id="w0-navbar" class="navbar navbar-expand-lg navbar-light">
+        <nav id="w0-navbar" class="navbar navbar-expand-lg">
 
         <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-navbar-collapse" aria-controls="w0-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
         <div id="w0-navbar-collapse" class="collapse navbar-collapse">
@@ -315,7 +315,7 @@ final class NavBarTest extends TestCase
             ->begin();
         $html .= NavBar::end();
         $expected = <<<'HTML'
-        <nav id="w0-navbar" class="navbar navbar-expand-lg navbar-light">
+        <nav id="w0-navbar" class="navbar navbar-expand-lg">
         <div class="text-link">
 
         <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-navbar-collapse" aria-controls="w0-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
@@ -353,12 +353,12 @@ final class NavBarTest extends TestCase
         $html .= NavBar::end();
 
         $expected = <<<'HTML'
-        <nav id="w0-navbar" class="navbar navbar-light">
+        <nav id="w0-navbar" class="navbar">
         <div class="container">
         <a class="navbar-brand" href="/">My Company</a>
         <ul id="w1-nav" class="mr-auto nav"><li class="nav-item"><a class="nav-link" href="#">Home</a></li>
         <li class="nav-item"><a class="nav-link" href="#">Link</a></li>
-        <li class="dropdown nav-item"><a class="dropdown-toggle nav-link" href="#" data-bs-toggle="dropdown">Dropdown</a><ul id="w2-dropdown" class="dropdown-menu" aria-expanded="false">
+        <li class="dropdown nav-item"><a class="dropdown-toggle nav-link" href="#" data-bs-toggle="dropdown">Dropdown</a><ul id="w2-dropdown" class="dropdown-menu">
         <li><a class="dropdown-item" href="#">Action</a></li>
         <li><a class="dropdown-item" href="#">Another action</a></li>
         <li><hr class="dropdown-divider"></li>
@@ -388,7 +388,7 @@ final class NavBarTest extends TestCase
                     ->expandSize($size)
                     ->begin() . NavBar::end();
             $expected = <<<HTML
-            <nav id="expanded-navbar" class="navbar {$size} navbar-light">
+            <nav id="expanded-navbar" class="navbar {$size}">
             <div class="container">
             <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#expanded-navbar-collapse" aria-controls="expanded-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
             <div id="expanded-navbar-collapse" class="collapse navbar-collapse">
@@ -414,7 +414,7 @@ final class NavBarTest extends TestCase
         $html .= NavBar::end();
 
         $expected = <<<'HTML'
-        <nav id="w1-navbar" class="navbar navbar-light">
+        <nav id="w1-navbar" class="navbar">
         <div class="container">
         <button type="button" class="navbar-toggler" data-bs-toggle="offcanvas" data-bs-target="#w0-offcanvas" aria-controls="w0-offcanvas" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
@@ -448,7 +448,7 @@ final class NavBarTest extends TestCase
         $html .= NavBar::end();
 
         $expected = <<<'HTML'
-        <nav id="w1-navbar" class="navbar navbar-expand-xl navbar-light">
+        <nav id="w1-navbar" class="navbar navbar-expand-xl">
         <div class="container">
         <button type="button" class="navbar-toggler" data-bs-toggle="offcanvas" data-bs-target="#w0-offcanvas" aria-controls="w0-offcanvas" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
@@ -490,7 +490,7 @@ final class NavBarTest extends TestCase
         $html .= NavBar::end();
 
         $expected = <<<'HTML'
-        <nav id="w0-navbar" class="navbar navbar-light">
+        <nav id="w0-navbar" class="navbar">
         <div class="container-fluid">
         <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#navbarToggleExternalContent" aria-controls="navbarToggleExternalContent" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
@@ -506,27 +506,24 @@ final class NavBarTest extends TestCase
     {
         $themes = [
             NavBar::THEME_LIGHT => [
-                'bg-light',
-                'bg-white',
+                'navbar-light',
             ],
             NavBar::THEME_DARK => [
-                'bg-dark',
-                'bg-primary',
+                'navbar-dark',
             ],
         ];
 
         foreach ($themes as $theme => $classNames) {
             foreach ($classNames as $class) {
                 $html = NavBar::widget()
-                    ->theme($theme)
+                    ->withTheme($theme)
                     ->options([
-                        'class' => $class,
                         'id' => 'expanded-navbar',
                     ])
                     ->begin();
                 $html .= NavBar::end();
                 $expected = <<<HTML
-                <nav id="expanded-navbar" class="{$class} navbar navbar-expand-lg {$theme}">
+                <nav id="expanded-navbar" class="navbar navbar-expand-lg {$class}" data-bs-theme="{$theme}">
                 <div class="container">
                 <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#expanded-navbar-collapse" aria-controls="expanded-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
                 <div id="expanded-navbar-collapse" class="collapse navbar-collapse">

--- a/tests/NavTest.php
+++ b/tests/NavTest.php
@@ -46,7 +46,7 @@ final class NavTest extends TestCase
             ->render();
         $expected = <<<'HTML'
         <ul id="w0-nav" class="nav"><li class="nav-item"><a class="nav-link disabled" href="#" tabindex="-1" aria-disabled="true">Page1</a></li>
-        <li class="dropdown nav-item"><a class="dropdown-toggle nav-link" href="#" data-bs-toggle="dropdown">Dropdown1</a><ul id="w1-dropdown" class="dropdown-menu" aria-expanded="false">
+        <li class="dropdown nav-item"><a class="dropdown-toggle nav-link" href="#" data-bs-toggle="dropdown">Dropdown1</a><ul id="w1-dropdown" class="dropdown-menu">
         <li><h6 class="dropdown-header">Page2</h6></li>
         <li><h6 class="dropdown-header">Page3</h6></li>
         </ul></li>
@@ -93,7 +93,7 @@ final class NavTest extends TestCase
             ->render();
         $expected = <<<'HTML'
         <ul id="w0-nav" class="nav"><li class="nav-item"><a class="nav-link" href="#">Page1</a></li>
-        <li class="dropdown nav-item"><a class="dropdown-toggle nav-link" href="#" data-bs-toggle="dropdown">Dropdown1</a><ul id="test1" class="test dropdown-menu" aria-expanded="false" data-id="t1">
+        <li class="dropdown nav-item"><a class="dropdown-toggle nav-link" href="#" data-bs-toggle="dropdown">Dropdown1</a><ul id="test1" class="test dropdown-menu" data-id="t1">
         <li><h6 class="dropdown-header">Page2</h6></li>
         <li><h6 class="dropdown-header">Page3</h6></li>
         </ul></li></ul>
@@ -126,7 +126,7 @@ final class NavTest extends TestCase
             ->render();
         $expected = <<<'HTML'
         <ul id="w0-nav" class="nav"><li class="nav-item"><a class="nav-link" href="#">Page1</a></li>
-        <li class="dropdown nav-item"><a class="dropdown-toggle nav-link" href="#" data-bs-toggle="dropdown">Dropdown1</a><ul id="w1-dropdown" class="dropdown-menu" aria-expanded="false">
+        <li class="dropdown nav-item"><a class="dropdown-toggle nav-link" href="#" data-bs-toggle="dropdown">Dropdown1</a><ul id="w1-dropdown" class="dropdown-menu">
         <li><h6 class="dropdown-header">Page2</h6></li>
         <li><h6 class="dropdown-header">Page3</h6></li>
         </ul></li>
@@ -216,7 +216,7 @@ final class NavTest extends TestCase
             ->render();
         $expected = <<<'HTML'
         <ul id="w0-nav" class="nav"><li class="nav-item"><a class="nav-link" href="#">Item1</a></li>
-        <li class="dropdown nav-item"><a class="dropdown-toggle nav-link" href="#" data-bs-toggle="dropdown">Item2</a><ul id="w1-dropdown" class="dropdown-menu" aria-expanded="false">
+        <li class="dropdown nav-item"><a class="dropdown-toggle nav-link" href="#" data-bs-toggle="dropdown">Item2</a><ul id="w1-dropdown" class="dropdown-menu">
         <li><a class="dropdown-item" href="site/index">Page2</a></li>
         <li><h6 class="dropdown-header">Page3</h6></li>
         </ul></li></ul>
@@ -247,7 +247,7 @@ final class NavTest extends TestCase
             ->render();
         $expected = <<<'HTML'
         <ul id="w0-nav" class="nav"><li class="nav-item"><a class="nav-link" href="#">Item1</a></li>
-        <li class="dropdown nav-item"><a class="dropdown-toggle nav-link" href="#" data-bs-toggle="dropdown">Item2</a><ul id="w1-dropdown" class="dropdown-menu" aria-expanded="false">
+        <li class="dropdown nav-item"><a class="dropdown-toggle nav-link" href="#" data-bs-toggle="dropdown">Item2</a><ul id="w1-dropdown" class="dropdown-menu">
         <li><a class="dropdown-item" href="/site/index">Page2</a></li>
         <li><h6 class="dropdown-header">Page3</h6></li>
         </ul></li></ul>
@@ -280,8 +280,8 @@ final class NavTest extends TestCase
             ])
             ->render();
         $expected = <<<'HTML'
-        <ul id="w0-nav" class="nav"><li class="dropdown nav-item"><a class="dropdown-toggle nav-link active" href="#" data-bs-toggle="dropdown">Dropdown</a><ul id="w1-dropdown" class="dropdown-menu" aria-expanded="false">
-        <li class="dropdown" aria-expanded="false"><a class="active dropdown-item dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-haspopup="true" aria-expanded="false" role="button">Sub-dropdown</a><ul id="w2-dropdown" class="dropdown-menu" aria-expanded="false">
+        <ul id="w0-nav" class="nav"><li class="dropdown nav-item"><a class="dropdown-toggle nav-link active" href="#" data-bs-toggle="dropdown">Dropdown</a><ul id="w1-dropdown" class="dropdown-menu">
+        <li class="dropdown" aria-expanded="false"><a class="active dropdown-item dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-haspopup="true" aria-expanded="false" role="button">Sub-dropdown</a><ul id="w2-dropdown" class="dropdown-menu">
         <li><h6 class="dropdown-header">Page</h6></li>
         </ul></li>
         </ul></li></ul>
@@ -376,7 +376,7 @@ final class NavTest extends TestCase
             ])
             ->render();
         $expected = <<<'HTML'
-        <ul id="w0-nav" class="nav"><li class="dropdown nav-item"><a class="dropdown-toggle nav-link" href="#" data-bs-toggle="dropdown">&lt;span&gt;&lt;i class=fas fas-test&gt;&lt;/i&gt;Dropdown1&lt;/span&gt;</a><ul id="w1-dropdown" class="dropdown-menu" aria-expanded="false">
+        <ul id="w0-nav" class="nav"><li class="dropdown nav-item"><a class="dropdown-toggle nav-link" href="#" data-bs-toggle="dropdown">&lt;span&gt;&lt;i class=fas fas-test&gt;&lt;/i&gt;Dropdown1&lt;/span&gt;</a><ul id="w1-dropdown" class="dropdown-menu">
         <li><h6 class="dropdown-header">Page2</h6></li>
         <li><h6 class="dropdown-header">Page3</h6></li>
         </ul></li>
@@ -398,7 +398,7 @@ final class NavTest extends TestCase
             ])
             ->render();
         $expected = <<<'HTML'
-        <ul id="w2-nav" class="nav"><li class="dropdown nav-item"><a class="dropdown-toggle nav-link" href="#" data-bs-toggle="dropdown"><span><i class=fas fas-test></i>Dropdown1</span></a><ul id="w3-dropdown" class="dropdown-menu" aria-expanded="false">
+        <ul id="w2-nav" class="nav"><li class="dropdown nav-item"><a class="dropdown-toggle nav-link" href="#" data-bs-toggle="dropdown"><span><i class=fas fas-test></i>Dropdown1</span></a><ul id="w3-dropdown" class="dropdown-menu">
         <li><h6 class="dropdown-header">Page2</h6></li>
         <li><h6 class="dropdown-header">Page3</h6></li>
         </ul></li>
@@ -426,7 +426,7 @@ final class NavTest extends TestCase
             ])
             ->render();
         $expected = <<<'HTML'
-        <ul id="w0-nav" class="nav"><li class="custom-item-class dropdown nav-item"><a class="dropdown-toggle nav-link" href="#" data-bs-toggle="dropdown">&lt;span&gt;&lt;i class=fas fas-test&gt;&lt;/i&gt;Dropdown1&lt;/span&gt;</a><ul id="w1-dropdown" class="dropdown-menu" aria-expanded="false">
+        <ul id="w0-nav" class="nav"><li class="custom-item-class dropdown nav-item"><a class="dropdown-toggle nav-link" href="#" data-bs-toggle="dropdown">&lt;span&gt;&lt;i class=fas fas-test&gt;&lt;/i&gt;Dropdown1&lt;/span&gt;</a><ul id="w1-dropdown" class="dropdown-menu">
         <li><h6 class="dropdown-header">Page2</h6></li>
         <li><h6 class="dropdown-header">Page3</h6></li>
         </ul></li></ul>
@@ -454,7 +454,7 @@ final class NavTest extends TestCase
             ])
             ->render();
         $expected = <<<'HTML'
-        <ul id="w0-nav" class="nav"><li class="dropdown nav-item"><a class="custom-link-class dropdown-toggle nav-link" href="#" data-bs-toggle="dropdown">&lt;span&gt;&lt;i class=fas fas-test&gt;&lt;/i&gt;Dropdown1&lt;/span&gt;</a><ul id="w1-dropdown" class="dropdown-menu" aria-expanded="false">
+        <ul id="w0-nav" class="nav"><li class="dropdown nav-item"><a class="custom-link-class dropdown-toggle nav-link" href="#" data-bs-toggle="dropdown">&lt;span&gt;&lt;i class=fas fas-test&gt;&lt;/i&gt;Dropdown1&lt;/span&gt;</a><ul id="w1-dropdown" class="dropdown-menu">
         <li><h6 class="dropdown-header">Page2</h6></li>
         <li><h6 class="dropdown-header">Page3</h6></li>
         </ul></li></ul>
@@ -482,7 +482,7 @@ final class NavTest extends TestCase
             ])
             ->render();
         $expected = <<<'HTML'
-        <ul id="w0-nav" class="nav"><li class="dropdown nav-item"><a class="dropdown-toggle nav-link" href="#" data-bs-toggle="dropdown">&lt;span&gt;&lt;i class=fas fas-test&gt;&lt;/i&gt;Dropdown1&lt;/span&gt;</a><ul id="w1-dropdown" class="dropdown-menu-dark dropdown-menu" aria-expanded="false">
+        <ul id="w0-nav" class="nav"><li class="dropdown nav-item"><a class="dropdown-toggle nav-link" href="#" data-bs-toggle="dropdown">&lt;span&gt;&lt;i class=fas fas-test&gt;&lt;/i&gt;Dropdown1&lt;/span&gt;</a><ul id="w1-dropdown" class="dropdown-menu-dark dropdown-menu">
         <li><h6 class="dropdown-header">Page2</h6></li>
         <li><h6 class="dropdown-header">Page3</h6></li>
         </ul></li></ul>
@@ -509,7 +509,7 @@ final class NavTest extends TestCase
             ])
             ->render();
         $expected = <<<'HTML'
-        <ul id="w0-nav" class="nav"><li class="dropdown nav-item"><a class="dropdown-toggle nav-link active custom-active-class" href="#" data-bs-toggle="dropdown">&lt;span&gt;&lt;i class=fas fas-test&gt;&lt;/i&gt;Dropdown1&lt;/span&gt;</a><ul id="w1-dropdown" class="dropdown-menu" aria-expanded="false">
+        <ul id="w0-nav" class="nav"><li class="dropdown nav-item"><a class="dropdown-toggle nav-link active custom-active-class" href="#" data-bs-toggle="dropdown">&lt;span&gt;&lt;i class=fas fas-test&gt;&lt;/i&gt;Dropdown1&lt;/span&gt;</a><ul id="w1-dropdown" class="dropdown-menu">
         <li><h6 class="dropdown-header">Page2</h6></li>
         <li><h6 class="dropdown-header">Page3</h6></li>
         </ul></li></ul>

--- a/tests/OffcanvasTest.php
+++ b/tests/OffcanvasTest.php
@@ -277,4 +277,56 @@ final class OffcanvasTest extends TestCase
 
         $this->assertEqualsHTML($expected, $html);
     }
+
+    public function testThemes(): void
+    {
+        Offcanvas::counter(0);
+
+        $html = Offcanvas::widget()
+            ->title('Offcanvas title')
+            ->withDarkTheme()
+            ->withoutBackdrop()
+            ->begin();
+        $html .= '<p>Some content here</p>';
+        $html .= Offcanvas::end();
+
+        $expected = <<<'HTML'
+        <div id="w0-offcanvas" class="offcanvas offcanvas-start" tabindex="-1" aria-labelledby="w0-offcanvas-title" data-bs-backdrop="false" data-bs-theme="dark">
+        <header class="offcanvas-header">
+        <h5 id="w0-offcanvas-title" class="offcanvas-title">Offcanvas title</h5>
+        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="offcanvas"></button>
+        </header>
+        <div class="offcanvas-body">
+        <p>Some content here</p>
+        </div>
+        </div>
+        HTML;
+
+        $this->assertEqualsHTML($expected, $html);
+
+
+        Offcanvas::counter(0);
+
+        $html = Offcanvas::widget()
+            ->title('Offcanvas title')
+            ->withTheme('red')
+            ->withoutBackdrop()
+            ->begin();
+        $html .= '<p>Some content here</p>';
+        $html .= Offcanvas::end();
+
+        $expected = <<<'HTML'
+        <div id="w0-offcanvas" class="offcanvas offcanvas-start" tabindex="-1" aria-labelledby="w0-offcanvas-title" data-bs-backdrop="false" data-bs-theme="red">
+        <header class="offcanvas-header">
+        <h5 id="w0-offcanvas-title" class="offcanvas-title">Offcanvas title</h5>
+        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="offcanvas"></button>
+        </header>
+        <div class="offcanvas-body">
+        <p>Some content here</p>
+        </div>
+        </div>
+        HTML;
+
+        $this->assertEqualsHTML($expected, $html);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️

1. Add string|Stringable items to Dropdown
2. Add `begin() . Long content . end()` to Dropdown
3. Add [aligment options](https://getbootstrap.com/docs/5.3/components/dropdowns/#menu-alignment) to Dropdown
4. Add [theme](https://getbootstrap.com/docs/5.3/components/dropdowns/#dark-dropdowns) both for < 5.3 and >= 5.3 versions (now works with Button, NavNar, Dropdown, Offcanvas, DropdownButton)
5. Remove unnecessary `aria-expanded` attribute on menu. It must be set only on toggle element on Dropdown
6. Allow custom Dropdown class in DropdownButton
7. Rename `DropdownButton::dropdown` to `DrodownButton:::items`