### PR TITLE
Collapse improvements

### DIFF
--- a/src/AbstractCloseButtonWidget.php
+++ b/src/AbstractCloseButtonWidget.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Bootstrap5;
+
+use Stringable;
+use Yiisoft\Arrays\ArrayHelper;
+use Yiisoft\Html\Html;
+use Yiisoft\Html\Tag\Base\Tag;
+
+abstract class AbstractCloseButtonWidget extends AbstractToggleWidget
+{
+    protected ?array $closeButtonOptions = [];
+    protected string|Stringable $closeButtonLabel = '';
+    protected bool $encodeCloseButton = true;
+
+    /**
+     * The HTML attributes for the widget close button tag. The following special options are recognized.
+     *
+     * {@see Html::renderTagAttributes()} for details on how attributes are being rendered.
+     */
+    public function withCloseButtonOptions(?array $options): static
+    {
+        $new = clone $this;
+        $new->closeButtonOptions = $options;
+
+        return $new;
+    }
+
+    /**
+     * Disable close button.
+     */
+    public function withoutCloseButton(): static
+    {
+        return $this->withCloseButtonOptions(null);
+    }
+
+    public function withCloseButtonLabel(string|Stringable $label): static
+    {
+        $new = clone $this;
+        $new->closeButtonLabel = $label;
+
+        return $new;
+    }
+
+    public function withEncodeCloseButton(bool $encode): static
+    {
+        $new = clone $this;
+        $new->encodeCloseButton = $encode;
+
+        return $new;
+    }
+
+    public function renderCloseButton(): ?Tag
+    {
+        $options = $this->closeButtonOptions;
+
+        if ($options === null) {
+            return null;
+        }
+
+        $tagName = ArrayHelper::remove($options, 'tag', 'button');
+
+        Html::addCssClass($options, ['widget' => 'btn-close']);
+
+        $label = (string) $this->closeButtonLabel;
+        $options['data-bs-dismiss'] = $this->toggleComponent();
+
+        if (empty($label) && !isset($options['aria-label']) && !isset($options['aria']['label'])) {
+            $options['aria-label'] = 'Close';
+        }
+
+        if ($tagName !== 'button') {
+            $options['role'] = 'button';
+        } elseif (!isset($options['type'])) {
+            $options['type'] = 'button';
+        }
+
+        return Html::tag($tagName, $label, $options)
+            ->encode($this->encodeCloseButton);
+    }
+}

--- a/src/AbstractToggleWidget.php
+++ b/src/AbstractToggleWidget.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Bootstrap5;
+
+use Stringable;
+use Yiisoft\Arrays\ArrayHelper;
+use Yiisoft\Html\Html;
+use Yiisoft\Html\Tag\Base\Tag;
+
+abstract class AbstractToggleWidget extends Widget
+{
+    protected array $toggleOptions = [];
+    protected string|Stringable $toggleLabel = '';
+    protected bool $renderToggle = true;
+
+    abstract protected function toggleComponent(): string;
+
+    public function withToggleOptions(array $options): static
+    {
+        $new = clone $this;
+        $new->toggleOptions = $options;
+
+        return $new;
+    }
+
+    public function withToggleLabel(string|Stringable $label): static
+    {
+        $new = clone $this;
+        $new->toggleLabel = $label;
+
+        return $new;
+    }
+
+    public function withToggle(bool $value): static
+    {
+        if ($this->renderToggle === $value) {
+            return $this;
+        }
+
+        $new = clone $this;
+        $new->renderToggle = $value;
+
+        return $new;
+    }
+
+    protected function prepareToggleOptions(): array
+    {
+        $options = $this->toggleOptions;
+        $tagName = ArrayHelper::remove($options, 'tag', 'button');
+        $encode = ArrayHelper::remove($options, 'encode', true);
+        $options['data-bs-toggle'] = $this->toggleComponent();
+
+        if (!isset($options['aria-controls']) && !isset($options['aria']['controls'])) {
+            $options['aria-controls'] = $this->getId();
+        }
+
+        if ($tagName !== 'button') {
+            $options['role'] = 'button';
+        } elseif (!isset($options['type'])) {
+            $options['type'] = 'button';
+        }
+
+        if ($tagName === 'a' && !isset($options['href'])) {
+            $options['href'] = '#' . $this->getId();
+        } elseif (!isset($options['data-bs-target']) && !isset($options['data']['bs-target'])) {
+            $options['data-bs-target'] = '#' . $this->getId();
+        }
+
+        return [$tagName, $options, $encode];
+    }
+
+    public function renderToggle(): Tag
+    {
+        [$tagName, $options, $encode] = $this->prepareToggleOptions();
+
+        return Html::tag($tagName, $this->toggleLabel, $options)
+            ->encode($encode);
+    }
+}

--- a/src/Collapse.php
+++ b/src/Collapse.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Bootstrap5;
+
+use Stringable;
+use Yiisoft\Arrays\ArrayHelper;
+use Yiisoft\Html\Html;
+use function array_key_exists;
+
+/**
+ * Collapse renders an collapse bootstrap JavaScript component.
+ *
+ * For example
+ *
+ * $collapse =Collapse::widget()
+ *      ->withTitle('Foo')
+ *      ->withContent('Bar');
+ *
+ * echo $collapse->render();
+ *
+ * Or
+ *
+ * $collapse = $collapse->withToggle(false);
+ *
+ * echo '<p>' . $collapse->renderToggle() . '</p><div>Some other content</div>' . $collapse->render();
+ */
+final class Collapse extends AbstractToggleWidget
+{
+    private array $options = [];
+    private array $bodyOptions = [
+        'tag' => 'div',
+    ];
+    private string|Stringable $content = '';
+    private bool $horizontal = false;
+    private bool $collapsed = false;
+    private ?string $tagName = null;
+
+    public function getId(?string $suffix = '-collapse'): ?string
+    {
+        return $this->options['id'] ?? parent::getId($suffix);
+    }
+
+    protected function toggleComponent(): string
+    {
+        return 'collapse';
+    }
+
+    public function withOptions(array $options): self
+    {
+        $new = clone $this;
+        $new->options = $options;
+
+        return $new;
+    }
+
+    public function withBodyOptions(array $options): self
+    {
+        $new = clone $this;
+        $new->bodyOptions = $options;
+
+        if (!array_key_exists('tag', $this->bodyOptions)) {
+            $this->bodyOptions['tag'] = 'div';
+        }
+
+        return $new;
+    }
+
+    public function withContent(string|Stringable $content): self
+    {
+        $new = clone $this;
+        $new->content = $content;
+
+        return $new;
+    }
+
+    public function withHorizontal(bool $horizontal): self
+    {
+        $new = clone $this;
+        $new->horizontal = $horizontal;
+
+        return $new;
+    }
+
+    public function withCollapsed(bool $collapsed): self
+    {
+        $new = clone $this;
+        $new->collapsed = $collapsed;
+
+        return $new;
+    }
+
+    private function prepareOptions(): array
+    {
+        $options = $this->options;
+        $options['id'] = $this->getId();
+
+        $classNames = [
+            'widget' => 'collapse',
+        ];
+
+        if ($this->horizontal) {
+            $classNames[] = 'collapse-horizontal';
+        }
+
+        if ($this->collapsed) {
+            $classNames[] = 'show';
+        }
+
+        Html::addCssClass($options, $classNames);
+
+        return $options;
+    }
+
+    private function prepareBodyOptions(): array
+    {
+        $options = $this->bodyOptions;
+        Html::addCssClass($options, ['widget' => 'card card-body']);
+
+        return $options;
+    }
+
+    protected function prepareToggleOptions(): array
+    {
+        [$tagName, $options, $encode] = parent::prepareToggleOptions();
+
+        $options['aria-expanded'] = $this->collapsed ? 'true' : 'false';
+
+        return [$tagName, $options, $encode];
+    }
+
+    public function begin(): ?string
+    {
+        parent::begin();
+
+        $options = $this->prepareOptions();
+        $bodyOptions = $this->prepareBodyOptions();
+        $this->tagName = ArrayHelper::remove($options, 'tag', 'div');
+        $html = $this->renderToggle ? $this->renderToggle() : '';
+        $html .= Html::openTag($this->tagName, $options);
+
+        if ($bodyTag = ArrayHelper::remove($bodyOptions, 'tag')) {
+            $html .= Html::openTag($bodyTag, $bodyOptions);
+        }
+
+        return $html;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function render(): string
+    {
+        if ($tagName = $this->tagName) {
+            $this->tagName = null;
+
+            if (isset($this->bodyOptions['tag'])) {
+                return Html::closeTag($this->bodyOptions['tag']) . Html::closeTag($tagName);
+            }
+
+            return Html::closeTag($tagName);
+        }
+
+        if ($this->renderToggle) {
+            return $this->renderToggle() . $this->renderCollapse();
+        }
+
+        return $this->renderCollapse();
+    }
+
+    private function renderCollapse(): string
+    {
+        $options = $this->prepareOptions();
+        $tagName = ArrayHelper::remove($options, 'tag', 'div');
+
+        return Html::tag($tagName, $this->renderBody(), $options)
+            ->encode(false)
+            ->render();
+    }
+
+    private function renderBody(): string
+    {
+        $options = $this->prepareBodyOptions();
+        $tagName = ArrayHelper::remove($options, 'tag', 'div');
+        $encode = ArrayHelper::remove($options, 'encode');
+
+        if ($tagName === null) {
+            return $encode ? Html::encode($this->content) : (string) $this->content;
+        }
+
+        return Html::tag($tagName, $this->content, $options)
+            ->encode($encode)
+            ->render();
+    }
+}

--- a/src/Offcanvas.php
+++ b/src/Offcanvas.php
@@ -7,7 +7,7 @@ namespace Yiisoft\Yii\Bootstrap5;
 use Yiisoft\Arrays\ArrayHelper;
 use Yiisoft\Html\Html;
 
-final class Offcanvas extends Widget
+final class Offcanvas extends AbstractCloseButtonWidget
 {
     public const PLACEMENT_TOP = 'offcanvas-top';
     public const PLACEMENT_END = 'offcanvas-end';
@@ -18,17 +18,20 @@ final class Offcanvas extends Widget
     private array $headerOptions = [];
     private array $titleOptions = [];
     private array $bodyOptions = [];
-    private array $closeButtonOptions = [
-        'class' => 'btn-close',
-    ];
     private ?string $title = null;
     private string $placement = self::PLACEMENT_START;
     private bool $scroll = false;
     private bool $withoutBackdrop = false;
+    protected bool $renderToggle = false;
 
     public function getId(?string $suffix = '-offcanvas'): ?string
     {
         return $this->options['id'] ?? parent::getId($suffix);
+    }
+
+    protected function toggleComponent(): string
+    {
+        return 'offcanvas';
     }
 
     /**
@@ -133,19 +136,6 @@ final class Offcanvas extends Widget
         return $new;
     }
 
-    /**
-     * The HTML attributes for the widget close button tag. The following special options are recognized.
-     *
-     * {@see Html::renderTagAttributes()} for details on how attributes are being rendered.
-     */
-    public function closeButtonOptions(array $options): self
-    {
-        $new = clone $this;
-        $new->closeButtonOptions = $options;
-
-        return $new;
-    }
-
     public function begin(): string
     {
         parent::begin();
@@ -181,7 +171,8 @@ final class Offcanvas extends Widget
             $options['data-bs-theme'] = $this->theme;
         }
 
-        $html = Html::openTag($tag, $options);
+        $html = $this->renderToggle ? $this->renderToggle() : '';
+        $html .= Html::openTag($tag, $options);
         $html .= $this->renderHeader();
         $html .= Html::openTag($bodyTag, $bodyOptions);
 
@@ -238,26 +229,6 @@ final class Offcanvas extends Widget
         }
 
         return Html::tag($tag, $this->title, $options)
-            ->encode($encode)
-            ->render();
-    }
-
-    /**
-     * Renders offcanvas close button.
-     *
-     * @return string the rendering close button.
-     */
-    private function renderCloseButton(): string
-    {
-        $options = $this->closeButtonOptions;
-        $label = ArrayHelper::remove($options, 'label', '');
-        $encode = ArrayHelper::remove($options, 'encode');
-
-        $options['type'] = 'button';
-        $options['aria-label'] = 'Close';
-        $options['data-bs-dismiss'] = 'offcanvas';
-
-        return Html::button($label, $options)
             ->encode($encode)
             ->render();
     }

--- a/tests/AccordionTest.php
+++ b/tests/AccordionTest.php
@@ -16,13 +16,18 @@ use Yiisoft\Yii\Bootstrap5\Accordion;
  */
 final class AccordionTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Accordion::counter(0);
+    }
+
     /**
      * @link https://getbootstrap.com/docs/5.0/components/accordion/#example
      */
     public function testRender(): void
     {
-        Accordion::counter(0);
-
         $html = Accordion::widget()
             ->items([
                 [
@@ -92,12 +97,12 @@ final class AccordionTest extends TestCase
 <div id="w0-accordion" class="accordion">
 
 <div class="accordion-item">
-<h2 id="w0-accordion-collapse0-heading" class="accordion-header">
-<button type="button" class="accordion-button" data-bs-toggle="collapse" aria-expanded="true" aria-controls="w0-accordion-collapse0" data-bs-target="#w0-accordion-collapse0">
+<h2 class="accordion-header">
+<button type="button" class="accordion-button" data-bs-toggle="collapse" aria-controls="w1-collapse" data-bs-target="#w1-collapse" aria-expanded="true">
 Accordion Item #1
 </button>
 </h2>
-<div id="w0-accordion-collapse0" class="accordion-collapse collapse show" aria-labelledby="w0-accordion-collapse0-heading" data-bs-parent="#w0-accordion">
+<div id="w1-collapse" class="accordion-collapse collapse show" data-bs-parent="#w0-accordion">
 <div class="accordion-body">
 This is the first items accordion body. It is shown by default, until the collapse plugin the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can  modify any of this with custom CSS or overriding our default variables. Its also worth noting that just about any HTML can go within the .accordion-body, though the transition does limit overflow.
 </div>
@@ -105,12 +110,12 @@ This is the first items accordion body. It is shown by default, until the collap
 </div>
 
 <div id="testId" class="testClass accordion-item">
-<h2 id="w0-accordion-collapse1-heading" class="accordion-header">
-<button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-expanded="false" aria-controls="w0-accordion-collapse1" data-bs-target="#w0-accordion-collapse1">
+<h2 class="accordion-header">
+<button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-controls="w2-collapse" data-bs-target="#w2-collapse" aria-expanded="false">
 Accordion Item #2
 </button>
 </h2>
-<div id="w0-accordion-collapse1" class="testContentOptions accordion-collapse collapse" aria-labelledby="w0-accordion-collapse1-heading" data-bs-parent="#w0-accordion">
+<div id="w2-collapse" class="testContentOptions accordion-collapse collapse" data-bs-parent="#w0-accordion">
 <div class="accordion-body">
 <strong>This is the second items accordion body.</strong> It is hidden by default, until the collapse plugin adds the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can modify any of this with custom CSS or overriding our default variables. Its also worth noting that just about any HTML can go within the <code>.accordion-body</code>, though the transition does limit overflow.
 </div>
@@ -118,12 +123,12 @@ Accordion Item #2
 </div>
 
 <div id="testId2" class="testClass2 accordion-item">
-<h2 id="w0-accordion-collapse2-heading" class="accordion-header">
-<button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-expanded="false" aria-controls="w0-accordion-collapse2" data-bs-target="#w0-accordion-collapse2">
+<h2 class="accordion-header">
+<button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-controls="w3-collapse" data-bs-target="#w3-collapse" aria-expanded="false">
 <b>Accordion Item #3</b>
 </button>
 </h2>
-<div id="w0-accordion-collapse2" class="testContentOptions2 accordion-collapse collapse" aria-labelledby="w0-accordion-collapse2-heading" data-bs-parent="#w0-accordion">
+<div id="w3-collapse" class="testContentOptions2 accordion-collapse collapse" data-bs-parent="#w0-accordion">
 <div class="accordion-body"><b>test content1</b>
 <strong>This is the third items accordion body.</strong> It is hidden by default, until the collapse plugin adds the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can modify any of this with custom CSS or overriding our default variables. Its also worth noting that just about any HTML can go within the <code>.accordion-body</code>, though the transition does limit overflow.
 </div>
@@ -131,12 +136,12 @@ Accordion Item #2
 </div>
 
 <div class="accordion-item">
-<h2 id="w0-accordion-collapse3-heading" class="accordion-header">
-<button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-expanded="false" aria-controls="w0-accordion-collapse3" data-bs-target="#w0-accordion-collapse3">
+<h2 class="accordion-header">
+<button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-controls="w4-collapse" data-bs-target="#w4-collapse" aria-expanded="false">
 Accordion item #3 - Stringable object
 </button>
 </h2>
-<div id="w0-accordion-collapse3" class="accordion-collapse collapse" aria-labelledby="w0-accordion-collapse3-heading" data-bs-parent="#w0-accordion">
+<div id="w4-collapse" class="accordion-collapse collapse" data-bs-parent="#w0-accordion">
 <div class="accordion-body">
 <b>This is a Stringable object</b>
 </div>
@@ -144,12 +149,12 @@ Accordion item #3 - Stringable object
 </div>
 
 <div class="accordion-item">
-<h2 id="w0-accordion-collapse4-heading" class="accordion-header">
-<button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-expanded="false" aria-controls="w0-accordion-collapse4" data-bs-target="#w0-accordion-collapse4">
+<h2 class="accordion-header">
+<button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-controls="w5-collapse" data-bs-target="#w5-collapse" aria-expanded="false">
 Accordion item #4 - array
 </button>
 </h2>
-<div id="w0-accordion-collapse4" class="accordion-collapse collapse" aria-labelledby="w0-accordion-collapse4-heading" data-bs-parent="#w0-accordion">
+<div id="w5-collapse" class="accordion-collapse collapse" data-bs-parent="#w0-accordion">
 <div class="accordion-body">
 <p>This is a standard string content</p>
 <b>This is a Stringable object</b>
@@ -167,8 +172,6 @@ HTML_WRAP;
      */
     public function testFlush(): void
     {
-        Accordion::counter(0);
-
         $html = Accordion::widget()
             ->items([
                 [
@@ -228,10 +231,10 @@ HTML_WRAP;
 <div id="w0-accordion" class="accordion accordion-flush">
 
 <div class="accordion-item">
-<h2 id="w0-accordion-collapse0-heading" class="accordion-header">
-<button type="button" class="accordion-button" data-bs-toggle="collapse" aria-expanded="true" aria-controls="w0-accordion-collapse0" data-bs-target="#w0-accordion-collapse0">Accordion Item #1</button>
+<h2 class="accordion-header">
+<button type="button" class="accordion-button" data-bs-toggle="collapse" aria-controls="w1-collapse" data-bs-target="#w1-collapse" aria-expanded="true">Accordion Item #1</button>
 </h2>
-<div id="w0-accordion-collapse0" class="accordion-collapse collapse show" aria-labelledby="w0-accordion-collapse0-heading" data-bs-parent="#w0-accordion">
+<div id="w1-collapse" class="accordion-collapse collapse show" data-bs-parent="#w0-accordion">
 <div class="accordion-body">
 This is the first items accordion body. It is shown by default, until the collapse plugin the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can  modify any of this with custom CSS or overriding our default variables. Its also worth noting that just about any HTML can go within the .accordion-body, though the transition does limit overflow.
 </div>
@@ -239,10 +242,10 @@ This is the first items accordion body. It is shown by default, until the collap
 </div>
 
 <div id="testId" class="testClass accordion-item">
-<h2 id="w0-accordion-collapse1-heading" class="accordion-header">
-<button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-expanded="false" aria-controls="w0-accordion-collapse1" data-bs-target="#w0-accordion-collapse1">Accordion Item #2</button>
+<h2 class="accordion-header">
+<button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-controls="w2-collapse" data-bs-target="#w2-collapse" aria-expanded="false">Accordion Item #2</button>
 </h2>
-<div id="w0-accordion-collapse1" class="testContentOptions accordion-collapse collapse" aria-labelledby="w0-accordion-collapse1-heading" data-bs-parent="#w0-accordion">
+<div id="w2-collapse" class="testContentOptions accordion-collapse collapse" data-bs-parent="#w0-accordion">
 <div class="accordion-body">
 <strong>This is the second items accordion body.</strong> It is hidden by default, until the collapse plugin adds the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can modify any of this with custom CSS or overriding our default variables. Its also worth noting that just about any HTML can go within the <code>.accordion-body</code>, though the transition does limit overflow.
 </div>
@@ -250,12 +253,12 @@ This is the first items accordion body. It is shown by default, until the collap
 </div>
 
 <div id="testId2" class="testClass2 accordion-item">
-<h2 id="w0-accordion-collapse2-heading" class="accordion-header">
-<button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-expanded="false" aria-controls="w0-accordion-collapse2" data-bs-target="#w0-accordion-collapse2">
+<h2 class="accordion-header">
+<button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-controls="w3-collapse" data-bs-target="#w3-collapse" aria-expanded="false">
 <b>Accordion Item #3</b>
 </button>
 </h2>
-<div id="w0-accordion-collapse2" class="testContentOptions2 accordion-collapse collapse" aria-labelledby="w0-accordion-collapse2-heading" data-bs-parent="#w0-accordion">
+<div id="w3-collapse" class="testContentOptions2 accordion-collapse collapse" data-bs-parent="#w0-accordion">
 <div class="accordion-body">
 <b>test content1</b>
 <strong>This is the third items accordion body.</strong> It is hidden by default, until the collapse plugin adds the appropriate classes that we use to style each element. These classes control the overall appearance, as well as the showing and hiding via CSS transitions. You can modify any of this with custom CSS or overriding our default variables. Its also worth noting that just about any HTML can go within the <code>.accordion-body</code>, though the transition does limit overflow.
@@ -324,8 +327,6 @@ HTML_WRAP;
 
     public function testAutoCloseItems(): void
     {
-        Accordion::counter(0);
-
         $items = [
             [
                 'label' => 'Item 1',
@@ -371,10 +372,10 @@ HTML_WRAP;
         <div id="w0-accordion" class="accordion">
 
         <div class="accordion-item">
-        <h2 id="w0-accordion-collapse0-heading" class="accordion-header">
-        <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-expanded="false" aria-controls="w0-accordion-collapse0" data-bs-target="#w0-accordion-collapse0">Item 1</button>
+        <h2 class="accordion-header">
+        <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-controls="w1-collapse" data-bs-target="#w1-collapse" aria-expanded="false">Item 1</button>
         </h2>
-        <div id="w0-accordion-collapse0" class="accordion-collapse collapse" aria-labelledby="w0-accordion-collapse0-heading" data-bs-parent="#w0-accordion">
+        <div id="w1-collapse" class="accordion-collapse collapse" data-bs-parent="#w0-accordion">
         <div class="accordion-body">
         Content 1
         </div>
@@ -382,10 +383,10 @@ HTML_WRAP;
         </div>
 
         <div class="accordion-item">
-        <h2 id="w0-accordion-collapse1-heading" class="accordion-header">
-        <button type="button" class="accordion-button" data-bs-toggle="collapse" aria-expanded="true" aria-controls="w0-accordion-collapse1" data-bs-target="#w0-accordion-collapse1">Item 2</button>
+        <h2 class="accordion-header">
+        <button type="button" class="accordion-button" data-bs-toggle="collapse" aria-controls="w2-collapse" data-bs-target="#w2-collapse" aria-expanded="true">Item 2</button>
         </h2>
-        <div id="w0-accordion-collapse1" class="accordion-collapse collapse show" aria-labelledby="w0-accordion-collapse1-heading" data-bs-parent="#w0-accordion">
+        <div id="w2-collapse" class="accordion-collapse collapse show" data-bs-parent="#w0-accordion">
         <div class="accordion-body">
         Content 2
         </div>
@@ -402,8 +403,6 @@ HTML_WRAP;
      */
     public function testItemToggleTag(): void
     {
-        Accordion::counter(0);
-
         $items = [
             [
                 'label' => 'Item 1',
@@ -417,26 +416,26 @@ HTML_WRAP;
 
         $html = Accordion::widget()
             ->items($items)
-            ->itemToggleOptions([
+            ->toggleOptions([
                 'tag' => 'a',
                 'class' => 'custom-toggle',
             ])
             ->render();
         $this->assertStringContainsString(
-            '<a class="custom-toggle accordion-button" href="#w0-accordion-collapse0"',
+            '<a class="custom-toggle accordion-button" href="#w1-collapse"',
             $html
         );
         $this->assertStringNotContainsString('<button', $html);
 
         $html = Accordion::widget()
             ->items($items)
-            ->itemToggleOptions([
+            ->toggleOptions([
                 'tag' => 'a',
                 'class' => ['widget' => 'custom-toggle'],
             ])
             ->render();
         $this->assertStringContainsString(
-            '<a class="custom-toggle accordion-button" href="#w1-accordion-collapse0"',
+            '<a class="custom-toggle accordion-button" href="#w4-collapse"',
             $html
         );
         $this->assertStringNotContainsString('collapse-toggle', $html);
@@ -444,8 +443,6 @@ HTML_WRAP;
 
     public function testOptions(): void
     {
-        Accordion::counter(0);
-
         $items = [
             [
                 'label' => 'Item 1',
@@ -465,10 +462,10 @@ HTML_WRAP;
         <div id="w0-accordion" class="testMe accordion">
 
         <div class="accordion-item">
-        <h2 id="w0-accordion-collapse0-heading" class="accordion-header">
-        <button type="button" class="accordion-button" data-bs-toggle="collapse" aria-expanded="true" aria-controls="w0-accordion-collapse0" data-bs-target="#w0-accordion-collapse0">Item 1</button>
+        <h2 class="accordion-header">
+        <button type="button" class="accordion-button" data-bs-toggle="collapse" aria-controls="w1-collapse" data-bs-target="#w1-collapse" aria-expanded="true">Item 1</button>
         </h2>
-        <div id="w0-accordion-collapse0" class="accordion-collapse collapse show" aria-labelledby="w0-accordion-collapse0-heading" data-bs-parent="#w0-accordion">
+        <div id="w1-collapse" class="accordion-collapse collapse show" data-bs-parent="#w0-accordion">
         <div class="accordion-body">
         Content 1
         </div>
@@ -476,10 +473,10 @@ HTML_WRAP;
         </div>
 
         <div class="accordion-item">
-        <h2 id="w0-accordion-collapse1-heading" class="accordion-header">
-        <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-expanded="false" aria-controls="w0-accordion-collapse1" data-bs-target="#w0-accordion-collapse1">Item 2</button>
+        <h2 class="accordion-header">
+        <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-controls="w2-collapse" data-bs-target="#w2-collapse" aria-expanded="false">Item 2</button>
         </h2>
-        <div id="w0-accordion-collapse1" class="accordion-collapse collapse" aria-labelledby="w0-accordion-collapse1-heading" data-bs-parent="#w0-accordion">
+        <div id="w2-collapse" class="accordion-collapse collapse" data-bs-parent="#w0-accordion">
         <div class="accordion-body">
         Content 2
         </div>
@@ -493,8 +490,6 @@ HTML_WRAP;
 
     public function testEncodeLabels(): void
     {
-        Accordion::counter(0);
-
         $items = [
             [
                 'label' => 'Item 1',
@@ -513,10 +508,10 @@ HTML_WRAP;
         <div id="w0-accordion" class="accordion">
 
         <div class="accordion-item">
-        <h2 id="w0-accordion-collapse0-heading" class="accordion-header">
-        <button type="button" class="accordion-button" data-bs-toggle="collapse" aria-expanded="true" aria-controls="w0-accordion-collapse0" data-bs-target="#w0-accordion-collapse0">Item 1</button>
+        <h2 class="accordion-header">
+        <button type="button" class="accordion-button" data-bs-toggle="collapse" aria-controls="w1-collapse" data-bs-target="#w1-collapse" aria-expanded="true">Item 1</button>
         </h2>
-        <div id="w0-accordion-collapse0" class="accordion-collapse collapse show" aria-labelledby="w0-accordion-collapse0-heading" data-bs-parent="#w0-accordion">
+        <div id="w1-collapse" class="accordion-collapse collapse show" data-bs-parent="#w0-accordion">
         <div class="accordion-body">
         Content 1
         </div>
@@ -524,10 +519,10 @@ HTML_WRAP;
         </div>
 
         <div class="accordion-item">
-        <h2 id="w0-accordion-collapse1-heading" class="accordion-header">
-        <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-expanded="false" aria-controls="w0-accordion-collapse1" data-bs-target="#w0-accordion-collapse1">&lt;span&gt;&lt;i class="fas fa-eye"&gt;Item 2&lt;/i&gt;&lt;/span&gt;</button>
+        <h2 class="accordion-header">
+        <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-controls="w2-collapse" data-bs-target="#w2-collapse" aria-expanded="false">&lt;span&gt;&lt;i class="fas fa-eye"&gt;Item 2&lt;/i&gt;&lt;/span&gt;</button>
         </h2>
-        <div id="w0-accordion-collapse1" class="accordion-collapse collapse" aria-labelledby="w0-accordion-collapse1-heading" data-bs-parent="#w0-accordion">
+        <div id="w2-collapse" class="accordion-collapse collapse" data-bs-parent="#w0-accordion">
         <div class="accordion-body">
         Content 2
         </div>
@@ -543,13 +538,13 @@ HTML_WRAP;
             ->withoutEncodeLabels()
             ->render();
         $expected = <<<'HTML'
-        <div id="w1-accordion" class="accordion">
+        <div id="w3-accordion" class="accordion">
 
         <div class="accordion-item">
-        <h2 id="w1-accordion-collapse0-heading" class="accordion-header">
-        <button type="button" class="accordion-button" data-bs-toggle="collapse" aria-expanded="true" aria-controls="w1-accordion-collapse0" data-bs-target="#w1-accordion-collapse0">Item 1</button>
+        <h2 class="accordion-header">
+        <button type="button" class="accordion-button" data-bs-toggle="collapse" aria-controls="w4-collapse" data-bs-target="#w4-collapse" aria-expanded="true">Item 1</button>
         </h2>
-        <div id="w1-accordion-collapse0" class="accordion-collapse collapse show" aria-labelledby="w1-accordion-collapse0-heading" data-bs-parent="#w1-accordion">
+        <div id="w4-collapse" class="accordion-collapse collapse show" data-bs-parent="#w3-accordion">
         <div class="accordion-body">
         Content 1
         </div>
@@ -557,10 +552,10 @@ HTML_WRAP;
         </div>
 
         <div class="accordion-item">
-        <h2 id="w1-accordion-collapse1-heading" class="accordion-header">
-        <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-expanded="false" aria-controls="w1-accordion-collapse1" data-bs-target="#w1-accordion-collapse1"><span><i class="fas fa-eye">Item 2</i></span></button>
+        <h2 class="accordion-header">
+        <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-controls="w5-collapse" data-bs-target="#w5-collapse" aria-expanded="false"><span><i class="fas fa-eye">Item 2</i></span></button>
         </h2>
-        <div id="w1-accordion-collapse1" class="accordion-collapse collapse" aria-labelledby="w1-accordion-collapse1-heading" data-bs-parent="#w1-accordion">
+        <div id="w5-collapse" class="accordion-collapse collapse" data-bs-parent="#w3-accordion">
         <div class="accordion-body">
         Content 2
         </div>
@@ -574,8 +569,6 @@ HTML_WRAP;
 
     public function testAllClose(): void
     {
-        Accordion::counter(0);
-
         $items = [
             [
                 'label' => 'Item 1',
@@ -596,10 +589,10 @@ HTML_WRAP;
         <div id="w0-accordion" class="accordion">
 
         <div class="accordion-item">
-        <h2 id="w0-accordion-collapse0-heading" class="accordion-header">
-        <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-expanded="false" aria-controls="w0-accordion-collapse0" data-bs-target="#w0-accordion-collapse0">Item 1</button>
+        <h2 class="accordion-header">
+        <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-controls="w1-collapse" data-bs-target="#w1-collapse" aria-expanded="false">Item 1</button>
         </h2>
-        <div id="w0-accordion-collapse0" class="accordion-collapse collapse" aria-labelledby="w0-accordion-collapse0-heading" data-bs-parent="#w0-accordion">
+        <div id="w1-collapse" class="accordion-collapse collapse" data-bs-parent="#w0-accordion">
         <div class="accordion-body">
         Content 1
         </div>
@@ -607,10 +600,10 @@ HTML_WRAP;
         </div>
 
         <div class="accordion-item">
-        <h2 id="w0-accordion-collapse1-heading" class="accordion-header">
-        <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-expanded="false" aria-controls="w0-accordion-collapse1" data-bs-target="#w0-accordion-collapse1">Item 2</button>
+        <h2 class="accordion-header">
+        <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-controls="w2-collapse" data-bs-target="#w2-collapse" aria-expanded="false">Item 2</button>
         </h2>
-        <div id="w0-accordion-collapse1" class="accordion-collapse collapse" aria-labelledby="w0-accordion-collapse1-heading" data-bs-parent="#w0-accordion">
+        <div id="w2-collapse" class="accordion-collapse collapse" data-bs-parent="#w0-accordion">
         <div class="accordion-body">
         Content 2
         </div>
@@ -643,10 +636,10 @@ HTML_WRAP;
         <div id="w0-accordion" class="accordion">
 
         <div class="accordion-item">
-        <h2 id="w0-accordion-collapse0-heading" class="accordion-header">
-        <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-expanded="false" aria-controls="w0-accordion-collapse0" data-bs-target="#w0-accordion-collapse0">Item 1</button>
+        <h2 class="accordion-header">
+        <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-controls="w1-collapse" data-bs-target="#w1-collapse" aria-expanded="false">Item 1</button>
         </h2>
-        <div id="w0-accordion-collapse0" class="accordion-collapse collapse" aria-labelledby="w0-accordion-collapse0-heading" data-bs-parent="#w0-accordion">
+        <div id="w1-collapse" class="accordion-collapse collapse" data-bs-parent="#w0-accordion">
         <div class="accordion-body">
         Content 1
         </div>
@@ -654,10 +647,178 @@ HTML_WRAP;
         </div>
 
         <div class="accordion-item">
-        <h2 id="w0-accordion-collapse1-heading" class="accordion-header">
-        <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-expanded="false" aria-controls="w0-accordion-collapse1" data-bs-target="#w0-accordion-collapse1">Item 2</button>
+        <h2 class="accordion-header">
+        <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-controls="w2-collapse" data-bs-target="#w2-collapse" aria-expanded="false">Item 2</button>
         </h2>
-        <div id="w0-accordion-collapse1" class="accordion-collapse collapse" aria-labelledby="w0-accordion-collapse1-heading" data-bs-parent="#w0-accordion">
+        <div id="w2-collapse" class="accordion-collapse collapse" data-bs-parent="#w0-accordion">
+        <div class="accordion-body">
+        Content 2
+        </div>
+        </div>
+        </div>
+
+        </div>
+        HTML;
+        $this->assertEqualsHTML($expected, $html);
+    }
+
+    public function testBodyOptions(): void
+    {
+        $items = [
+            [
+                'label' => 'Item 1',
+                'content' => 'Content 1',
+            ],
+            [
+                'label' => 'Item 2',
+                'content' => 'Content 2',
+                'bodyOptions' => [
+                    'class' => [
+                        'bg-success',
+                    ],
+                ],
+            ],
+        ];
+
+        $html = Accordion::widget()
+            ->items($items)
+            ->defaultExpand(false)
+            ->bodyOptions([
+                'tag' => 'section',
+                'class' => [
+                    'test_class',
+                ],
+            ])
+            ->render();
+        $expected = <<<'HTML'
+        <div id="w0-accordion" class="accordion">
+
+        <div class="accordion-item">
+        <h2 class="accordion-header">
+        <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-controls="w1-collapse" data-bs-target="#w1-collapse" aria-expanded="false">Item 1</button>
+        </h2>
+        <div id="w1-collapse" class="accordion-collapse collapse" data-bs-parent="#w0-accordion">
+        <section class="test_class accordion-body">
+        Content 1
+        </section>
+        </div>
+        </div>
+
+        <div class="accordion-item">
+        <h2 class="accordion-header">
+        <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-controls="w2-collapse" data-bs-target="#w2-collapse" aria-expanded="false">Item 2</button>
+        </h2>
+        <div id="w2-collapse" class="accordion-collapse collapse" data-bs-parent="#w0-accordion">
+        <div class="bg-success accordion-body">
+        Content 2
+        </div>
+        </div>
+        </div>
+
+        </div>
+        HTML;
+        $this->assertEqualsHTML($expected, $html);
+    }
+
+    public function testHeaderOptions(): void
+    {
+        $items = [
+            [
+                'label' => 'Item 1',
+                'content' => 'Content 1',
+            ],
+            [
+                'label' => 'Item 2',
+                'content' => 'Content 2',
+                'headerOptions' => [
+                    'class' => [
+                        'bg-success',
+                    ],
+                ],
+            ],
+        ];
+
+        $html = Accordion::widget()
+            ->items($items)
+            ->defaultExpand(false)
+            ->headerOptions([
+                'tag' => 'header',
+            ])
+            ->render();
+        $expected = <<<'HTML'
+        <div id="w0-accordion" class="accordion">
+
+        <div class="accordion-item">
+        <header class="accordion-header">
+        <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-controls="w1-collapse" data-bs-target="#w1-collapse" aria-expanded="false">Item 1</button>
+        </header>
+        <div id="w1-collapse" class="accordion-collapse collapse" data-bs-parent="#w0-accordion">
+        <div class="accordion-body">
+        Content 1
+        </div>
+        </div>
+        </div>
+
+        <div class="accordion-item">
+        <h2 class="bg-success accordion-header">
+        <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-controls="w2-collapse" data-bs-target="#w2-collapse" aria-expanded="false">Item 2</button>
+        </h2>
+        <div id="w2-collapse" class="accordion-collapse collapse" data-bs-parent="#w0-accordion">
+        <div class="accordion-body">
+        Content 2
+        </div>
+        </div>
+        </div>
+
+        </div>
+        HTML;
+        $this->assertEqualsHTML($expected, $html);
+    }
+
+    public function testContentOptions(): void
+    {
+        $items = [
+            [
+                'label' => 'Item 1',
+                'content' => 'Content 1',
+            ],
+            [
+                'label' => 'Item 2',
+                'content' => 'Content 2',
+                'contentOptions' => [
+                    'class' => [
+                        'bg-success',
+                    ],
+                ],
+            ],
+        ];
+
+        $html = Accordion::widget()
+            ->items($items)
+            ->defaultExpand(false)
+            ->contentOptions([
+                'tag' => 'article',
+            ])
+            ->render();
+        $expected = <<<'HTML'
+        <div id="w0-accordion" class="accordion">
+
+        <div class="accordion-item">
+        <h2 class="accordion-header">
+        <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-controls="w1-collapse" data-bs-target="#w1-collapse" aria-expanded="false">Item 1</button>
+        </h2>
+        <article id="w1-collapse" class="accordion-collapse collapse" data-bs-parent="#w0-accordion">
+        <div class="accordion-body">
+        Content 1
+        </div>
+        </article>
+        </div>
+
+        <div class="accordion-item">
+        <h2 class="accordion-header">
+        <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-controls="w2-collapse" data-bs-target="#w2-collapse" aria-expanded="false">Item 2</button>
+        </h2>
+        <div id="w2-collapse" class="bg-success accordion-collapse collapse" data-bs-parent="#w0-accordion">
         <div class="accordion-body">
         Content 2
         </div>

--- a/tests/CollapseTest.php
+++ b/tests/CollapseTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Bootstrap5\Tests;
+
+use Yiisoft\Yii\Bootstrap5\Collapse;
+
+final class CollapseTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Collapse::counter(0);
+    }
+
+    public function testSimpleCollapse(): void
+    {
+        $html = Collapse::widget()
+            ->withToggleLabel('Toggle')
+            ->withToggleOptions([
+                'class' => 'btn btn-primary',
+            ])
+            ->withContent('Collapse content')
+            ->render();
+
+        $expected = <<<'HTML'
+<button type="button" class="btn btn-primary" data-bs-toggle="collapse" aria-controls="w0-collapse" data-bs-target="#w0-collapse" aria-expanded="false">Toggle</button>
+<div id="w0-collapse" class="collapse">
+<div class="card card-body">
+Collapse content
+</div>
+</div>
+HTML;
+
+        $this->assertEqualsHTML($expected, $html);
+    }
+
+    public function testLinkCollapse(): void
+    {
+        $html = Collapse::widget()
+            ->withToggleLabel('Toggle')
+            ->withToggleOptions([
+                'tag' => 'a',
+            ])
+            ->withContent('Collapse content')
+            ->render();
+
+        $expected = <<<'HTML'
+<a href="#w0-collapse" data-bs-toggle="collapse" aria-controls="w0-collapse" role="button" aria-expanded="false">Toggle</a>
+<div id="w0-collapse" class="collapse">
+<div class="card card-body">
+Collapse content
+</div>
+</div>
+HTML;
+
+        $this->assertEqualsHTML($expected, $html);
+    }
+
+    public function testHorizontalCollapse(): void
+    {
+        $html = Collapse::widget()
+            ->withToggleLabel('Toggle')
+            ->withToggleOptions([
+                'class' => 'btn btn-primary',
+            ])
+            ->withHorizontal(true)
+            ->withContent('Collapse content')
+            ->render();
+
+        $expected = <<<'HTML'
+<button type="button" class="btn btn-primary" data-bs-toggle="collapse" aria-controls="w0-collapse" data-bs-target="#w0-collapse" aria-expanded="false">Toggle</button>
+<div id="w0-collapse" class="collapse collapse-horizontal">
+<div class="card card-body">
+Collapse content
+</div>
+</div>
+HTML;
+
+        $this->assertEqualsHTML($expected, $html);
+    }
+
+    public function testSeparateSwitcher(): void
+    {
+        Collapse::counter(0);
+
+        $collapse = Collapse::widget()
+            ->withToggleLabel('Toggle')
+            ->withToggleOptions([
+                'class' => 'btn btn-primary',
+            ])
+            ->withToggle(false)
+            ->withHorizontal(true)
+            ->withContent('Collapse content');
+
+        $html = '<p>' . $collapse->renderToggle() . '</p>' . $collapse->render();
+
+        $expected = <<<'HTML'
+<p>
+<button type="button" class="btn btn-primary" data-bs-toggle="collapse" aria-controls="w0-collapse" data-bs-target="#w0-collapse" aria-expanded="false">Toggle</button>
+</p>
+<div id="w0-collapse" class="collapse collapse-horizontal">
+<div class="card card-body">
+Collapse content
+</div>
+</div>
+HTML;
+
+        $this->assertEqualsHTML($expected, $html);
+    }
+
+    public function testWithoutBody(): void
+    {
+        $html = Collapse::widget()
+            ->withToggleLabel('Toggle')
+            ->withToggleOptions([
+                'class' => 'btn btn-primary',
+            ])
+            ->withBodyOptions([
+                'tag' => null,
+            ])
+            ->withContent('Collapse content')
+            ->render();
+
+        $expected = <<<'HTML'
+<button type="button" class="btn btn-primary" data-bs-toggle="collapse" aria-controls="w0-collapse" data-bs-target="#w0-collapse" aria-expanded="false">Toggle</button>
+<div id="w0-collapse" class="collapse">
+Collapse content
+</div>
+HTML;
+
+        $this->assertEqualsHTML($expected, $html);
+    }
+
+    public function testOuterContent(): void
+    {
+        $html = Collapse::widget()
+            ->withToggleLabel('Toggle')
+            ->withToggleOptions([
+                'class' => 'btn btn-primary',
+            ])
+            ->begin();
+        $html .= 'Very very very looooong content';
+        $html .= Collapse::end();
+
+        $expected = <<<'HTML'
+<button type="button" class="btn btn-primary" data-bs-toggle="collapse" aria-controls="w0-collapse" data-bs-target="#w0-collapse" aria-expanded="false">Toggle</button>
+<div id="w0-collapse" class="collapse">
+<div class="card card-body">
+Very very very looooong content
+</div>
+</div>
+HTML;
+        $this->assertEqualsHTML($expected, $html);
+    }
+
+    public function testBodyTag(): void
+    {
+        $html = Collapse::widget()
+            ->withToggleLabel('Toggle')
+            ->withToggleOptions([
+                'class' => 'btn btn-primary',
+            ])
+            ->withBodyOptions([
+                'tag' => 'article',
+            ])
+            ->withContent('Collapse content')
+            ->render();
+
+        $expected = <<<'HTML'
+<button type="button" class="btn btn-primary" data-bs-toggle="collapse" aria-controls="w0-collapse" data-bs-target="#w0-collapse" aria-expanded="false">Toggle</button>
+<div id="w0-collapse" class="collapse">
+<article class="card card-body">
+Collapse content
+</article>
+</div>
+HTML;
+
+        $this->assertEqualsHTML($expected, $html);
+    }
+}

--- a/tests/ModalTest.php
+++ b/tests/ModalTest.php
@@ -14,16 +14,22 @@ use Yiisoft\Yii\Bootstrap5\Modal;
  */
 final class ModalTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Modal::counter(0);
+    }
+
     public function testBodyOptions(): void
     {
-        Modal::counter(0);
-
         $html = Modal::widget()
             ->bodyOptions(['class' => 'modal-body test', 'style' => 'text-align:center;'])
+            ->withToggleLabel('Show')
             ->begin();
         $html .= Modal::end();
         $expected = <<<'HTML'
-<button type="button" data-bs-toggle="modal" data-bs-target="#w0-modal">Show</button>
+<button type="button" data-bs-toggle="modal" aria-controls="w0-modal" data-bs-target="#w0-modal">Show</button>
 <div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true">
 <div class="modal-dialog">
 <div class="modal-content">
@@ -42,33 +48,31 @@ HTML;
 
     public function testFooter(): void
     {
-        Modal::counter(0);
-
-        $html = Modal::widget()
-            ->footer(
-                Html::button(
-                    'Close',
-                    [
-                        'type' => 'button',
-                        'class' => ['btn', 'btn-secondary'],
-                        'data' => [
-                            'bs-dismiss' => 'modal',
-                        ],
-                    ]
-                ) . "\n" .
-                Html::button(
-                    'Save changes',
-                    [
-                        'type' => 'button',
-                        'class' => ['btn', 'btn-primary'],
-                    ]
-                )
+        $widget = Modal::widget()
+            ->withToggleLabel('Show');
+        $modal = $widget->footer(
+            $widget->withCloseButtonOptions([
+                'class' => [
+                    'widget' => 'btn',
+                    'btn-secondary',
+                ],
+            ])
+            ->withCloseButtonLabel('Close')
+            ->renderCloseButton() . "\n" .
+            Html::button(
+                'Save changes',
+                [
+                    'type' => 'button',
+                    'class' => ['btn', 'btn-primary'],
+                ]
             )
-            ->begin();
+        );
+
+        $html = $modal->begin();
         $html .= '<p>Woohoo, you\'re reading this text in a modal!</p>';
         $html .= Modal::end();
         $expected = <<<'HTML'
-<button type="button" data-bs-toggle="modal" data-bs-target="#w0-modal">Show</button>
+<button type="button" data-bs-toggle="modal" aria-controls="w0-modal" data-bs-target="#w0-modal">Show</button>
 <div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true">
 <div class="modal-dialog">
 <div class="modal-content">
@@ -91,10 +95,10 @@ HTML;
         Modal::counter(0);
 
         $html = Modal::widget()
-            ->toggleButton([
+            ->withToggleOptions([
                 'class' => ['btn', 'btn-primary'],
-                'label' => 'Launch demo modal',
             ])
+            ->withToggleLabel('Launch demo modal')
             ->footer(
                 Html::button(
                     'Close',
@@ -118,7 +122,7 @@ HTML;
         $html .= '<p>Woohoo, you\'re reading this text in a modal!</p>';
         $html .= Modal::end();
         $expected = <<<'HTML'
-<button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#w0-modal">Launch demo modal</button>
+<button type="button" class="btn btn-primary" data-bs-toggle="modal" aria-controls="w0-modal" data-bs-target="#w0-modal">Launch demo modal</button>
 <div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true">
 <div class="modal-dialog">
 <div class="modal-content">
@@ -141,12 +145,13 @@ HTML;
         Modal::counter(0);
 
         $html = Modal::widget()
-            ->closeButton(['class' => 'btn-lg btn-close'])
+            ->withCloseButtonOptions(['class' => 'btn-lg'])
+            ->withToggleLabel('Show')
             ->begin();
         $html .= '<p>Woohoo, you\'re reading this text in a modal!</p>';
         $html .= Modal::end();
         $expected = <<<'HTML'
-        <button type="button" data-bs-toggle="modal" data-bs-target="#w0-modal">Show</button>
+        <button type="button" data-bs-toggle="modal" aria-controls="w0-modal" data-bs-target="#w0-modal">Show</button>
         <div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true">
         <div class="modal-dialog">
         <div class="modal-content">
@@ -169,11 +174,12 @@ HTML;
 
         $html = Modal::widget()
             ->withoutCloseButton()
+            ->withToggleLabel('Show')
             ->begin();
         $html .= '<p>Woohoo, you\'re reading this text in a modal!</p>';
         $html .= Modal::end();
         $expected = <<<'HTML'
-        <button type="button" data-bs-toggle="modal" data-bs-target="#w0-modal">Show</button>
+        <button type="button" data-bs-toggle="modal" aria-controls="w0-modal" data-bs-target="#w0-modal">Show</button>
         <div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true">
         <div class="modal-dialog">
         <div class="modal-content">
@@ -195,11 +201,12 @@ HTML;
 
         $html = Modal::widget()
             ->footerOptions(['class' => 'text-dark'])
+            ->withToggleLabel('Show')
             ->begin();
         $html .= '<p>Woohoo, you\'re reading this text in a modal!</p>';
         $html .= Modal::end();
         $expected = <<<'HTML'
-        <button type="button" data-bs-toggle="modal" data-bs-target="#w0-modal">Show</button>
+        <button type="button" data-bs-toggle="modal" aria-controls="w0-modal" data-bs-target="#w0-modal">Show</button>
         <div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true">
         <div class="modal-dialog">
         <div class="modal-content">
@@ -221,12 +228,13 @@ HTML;
         Modal::counter(0);
 
         $html = Modal::widget()
+            ->withToggleLabel('Show')
             ->headerOptions(['class' => 'text-danger'])
             ->begin();
         $html .= '<p>Woohoo, you\'re reading this text in a modal!</p>';
         $html .= Modal::end();
         $expected = <<<'HTML'
-        <button type="button" data-bs-toggle="modal" data-bs-target="#w0-modal">Show</button>
+        <button type="button" data-bs-toggle="modal" aria-controls="w0-modal" data-bs-target="#w0-modal">Show</button>
         <div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true">
         <div class="modal-dialog">
         <div class="modal-content">
@@ -248,12 +256,13 @@ HTML;
         Modal::counter(0);
 
         $html = Modal::widget()
+            ->withToggleLabel('Show')
             ->options(['class' => 'testMe'])
             ->begin();
         $html .= '<p>Woohoo, you\'re reading this text in a modal!</p>';
         $html .= Modal::end();
         $expected = <<<'HTML'
-        <button type="button" data-bs-toggle="modal" data-bs-target="#w0-modal">Show</button>
+        <button type="button" data-bs-toggle="modal" aria-controls="w0-modal" data-bs-target="#w0-modal">Show</button>
         <div id="w0-modal" class="testMe modal fade" role="dialog" tabindex="-1" aria-hidden="true">
         <div class="modal-dialog">
         <div class="modal-content">
@@ -275,12 +284,13 @@ HTML;
         Modal::counter(0);
 
         $html = Modal::widget()
+            ->withToggleLabel('Show')
             ->title('My first modal.')
             ->begin();
         $html .= '<p>Woohoo, you\'re reading this text in a modal!</p>';
         $html .= Modal::end();
         $expected = <<<'HTML'
-        <button type="button" data-bs-toggle="modal" data-bs-target="#w0-modal">Show</button>
+        <button type="button" data-bs-toggle="modal" aria-controls="w0-modal" data-bs-target="#w0-modal">Show</button>
         <div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true" aria-labelledby="w0-modal-label">
         <div class="modal-dialog">
         <div class="modal-content">
@@ -302,12 +312,13 @@ HTML;
         Modal::counter(0);
 
         $html = Modal::widget()
+            ->withToggleLabel('Show')
             ->title('')
             ->begin();
         $html .= '<p>Woohoo, you\'re reading this text in a modal!</p>';
         $html .= Modal::end();
         $expected = <<<'HTML'
-        <button type="button" data-bs-toggle="modal" data-bs-target="#w0-modal">Show</button>
+        <button type="button" data-bs-toggle="modal" aria-controls="w0-modal" data-bs-target="#w0-modal">Show</button>
         <div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true">
         <div class="modal-dialog">
         <div class="modal-content">
@@ -329,13 +340,14 @@ HTML;
         Modal::counter(0);
 
         $html = Modal::widget()
+            ->withToggleLabel('Show')
             ->title('My first modal.')
             ->titleOptions(['class' => 'text-center'])
             ->begin();
         $html .= '<p>Woohoo, you\'re reading this text in a modal!</p>';
         $html .= Modal::end();
         $expected = <<<'HTML'
-        <button type="button" data-bs-toggle="modal" data-bs-target="#w0-modal">Show</button>
+        <button type="button" data-bs-toggle="modal" aria-controls="w0-modal" data-bs-target="#w0-modal">Show</button>
         <div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true" aria-labelledby="w0-modal-label">
         <div class="modal-dialog">
         <div class="modal-content">
@@ -352,12 +364,12 @@ HTML;
         $this->assertEqualsHTML($expected, $html);
     }
 
-    public function testWithoutTogleButton(): void
+    public function testWithoutToggleButton(): void
     {
         Modal::counter(0);
 
         $html = Modal::widget()
-            ->withoutToggleButton()
+            ->withToggle(false)
             ->begin();
         $html .= '<p>Woohoo, you\'re reading this text in a modal!</p>';
         $html .= Modal::end();
@@ -379,66 +391,100 @@ HTML;
         $this->assertEqualsHTML($expected, $html);
     }
 
-    public function testWithSize(): void
+    public static function sizeDataProvider(): array
+    {
+        return [
+            [
+                Modal::SIZE_LARGE,
+                <<<'HTML'
+                <button type="button" data-bs-toggle="modal" aria-controls="w0-modal" data-bs-target="#w0-modal">Show</button>
+                <div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true">
+                <div class="modal-dialog modal-lg">
+                <div class="modal-content">
+                <div class="modal-header">
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>
+                <div class="modal-body">
+                <p>Woohoo, you're reading this text in a modal!</p>
+                </div>
+
+                </div>
+                </div>
+                </div>
+                HTML,
+            ],
+
+            [
+                Modal::SIZE_SMALL,
+                <<<'HTML'
+                <button type="button" data-bs-toggle="modal" aria-controls="w0-modal" data-bs-target="#w0-modal">Show</button>
+                <div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true">
+                <div class="modal-dialog modal-sm">
+                <div class="modal-content">
+                <div class="modal-header">
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>
+                <div class="modal-body">
+                <p>Woohoo, you're reading this text in a modal!</p>
+                </div>
+
+                </div>
+                </div>
+                </div>
+                HTML,
+            ],
+
+            [
+                Modal::SIZE_EXTRA_LARGE,
+                <<<'HTML'
+                <button type="button" data-bs-toggle="modal" aria-controls="w0-modal" data-bs-target="#w0-modal">Show</button>
+                <div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true">
+                <div class="modal-dialog modal-xl">
+                <div class="modal-content">
+                <div class="modal-header">
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>
+                <div class="modal-body">
+                <p>Woohoo, you're reading this text in a modal!</p>
+                </div>
+
+                </div>
+                </div>
+                </div>
+                HTML,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider sizeDataProvider
+     * @return void
+     * @throws \Yiisoft\Definitions\Exception\CircularReferenceException
+     * @throws \Yiisoft\Definitions\Exception\InvalidConfigException
+     * @throws \Yiisoft\Definitions\Exception\NotInstantiableException
+     * @throws \Yiisoft\Factory\NotFoundException
+     */
+    public function testWithSize(string $size, string $expected): void
     {
         Modal::counter(0);
 
         $html = Modal::widget()
-            ->size(Modal::SIZE_LARGE)
+            ->withToggleLabel('Show')
+            ->size($size)
             ->begin();
         $html .= '<p>Woohoo, you\'re reading this text in a modal!</p>';
         $html .= Modal::end();
-        $expected = <<<'HTML'
-        <button type="button" data-bs-toggle="modal" data-bs-target="#w0-modal">Show</button>
-        <div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true">
-        <div class="modal-dialog modal-lg">
-        <div class="modal-content">
-        <div class="modal-header">
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>
-        <div class="modal-body">
-        <p>Woohoo, you're reading this text in a modal!</p>
-        </div>
 
-        </div>
-        </div>
-        </div>
-        HTML;
-        $this->assertEqualsHTML($expected, $html);
-
-        $html = Modal::widget()
-            ->size(Modal::SIZE_SMALL)
-            ->begin();
-        $html .= '<p>Woohoo, you\'re reading this text in a modal!</p>';
-        $html .= Modal::end();
-        $expected = <<<'HTML'
-        <button type="button" data-bs-toggle="modal" data-bs-target="#w1-modal">Show</button>
-        <div id="w1-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true">
-        <div class="modal-dialog modal-sm">
-        <div class="modal-content">
-        <div class="modal-header">
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>
-        <div class="modal-body">
-        <p>Woohoo, you're reading this text in a modal!</p>
-        </div>
-
-        </div>
-        </div>
-        </div>
-        HTML;
         $this->assertEqualsHTML($expected, $html);
     }
 
     public function testWithoutAnimation(): void
     {
-        Modal::counter(0);
-
         $html = Modal::widget()
+            ->withToggleLabel('Show')
             ->fade(false)
             ->begin();
         $html .= '<p>Woohoo, you\'re reading this text in a modal!</p>';
         $html .= Modal::end();
         $expected = <<<'HTML'
-        <button type="button" data-bs-toggle="modal" data-bs-target="#w0-modal">Show</button>
+        <button type="button" data-bs-toggle="modal" aria-controls="w0-modal" data-bs-target="#w0-modal">Show</button>
         <div id="w0-modal" class="modal" role="dialog" tabindex="-1" aria-hidden="true">
         <div class="modal-dialog">
         <div class="modal-content">
@@ -455,48 +501,139 @@ HTML;
         $this->assertEqualsHTML($expected, $html);
     }
 
-    public function testFullscreen(): void
+    public static function screenSizeDataProvider(): array
     {
-        $fullscreen = [
-            Modal::FULLSCREEN_ALWAYS,
-            Modal::FULLSCREEN_BELOW_SM,
-            Modal::FULLSCREEN_BELOW_MD,
-            Modal::FULLSCREEN_BELOW_LG,
-            Modal::FULLSCREEN_BELOW_XL,
-            Modal::FULLSCREEN_BELOW_XXL,
+        return [
+            [
+                Modal::FULLSCREEN_ALWAYS,
+                <<<HTML
+                <button type="button" data-bs-toggle="modal" aria-controls="w0-modal" data-bs-target="#w0-modal">Show</button>
+                <div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true">
+                <div class="modal-dialog modal-fullscreen">
+                <div class="modal-content">
+                <div class="modal-header">
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>
+                <div class="modal-body">
+                </div>
+                </div>
+                </div>
+                </div>
+                HTML,
+            ],
+
+            [
+                Modal::FULLSCREEN_BELOW_SM,
+                <<<HTML
+                <button type="button" data-bs-toggle="modal" aria-controls="w0-modal" data-bs-target="#w0-modal">Show</button>
+                <div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true">
+                <div class="modal-dialog modal-fullscreen-sm-down">
+                <div class="modal-content">
+                <div class="modal-header">
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>
+                <div class="modal-body">
+                </div>
+                </div>
+                </div>
+                </div>
+                HTML,
+            ],
+
+            [
+                Modal::FULLSCREEN_BELOW_MD,
+                <<<HTML
+                <button type="button" data-bs-toggle="modal" aria-controls="w0-modal" data-bs-target="#w0-modal">Show</button>
+                <div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true">
+                <div class="modal-dialog modal-fullscreen-md-down">
+                <div class="modal-content">
+                <div class="modal-header">
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>
+                <div class="modal-body">
+                </div>
+                </div>
+                </div>
+                </div>
+                HTML,
+            ],
+
+            [
+                Modal::FULLSCREEN_BELOW_LG,
+                <<<HTML
+                <button type="button" data-bs-toggle="modal" aria-controls="w0-modal" data-bs-target="#w0-modal">Show</button>
+                <div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true">
+                <div class="modal-dialog modal-fullscreen-lg-down">
+                <div class="modal-content">
+                <div class="modal-header">
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>
+                <div class="modal-body">
+                </div>
+                </div>
+                </div>
+                </div>
+                HTML,
+            ],
+
+            [
+                Modal::FULLSCREEN_BELOW_XL,
+                <<<HTML
+                <button type="button" data-bs-toggle="modal" aria-controls="w0-modal" data-bs-target="#w0-modal">Show</button>
+                <div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true">
+                <div class="modal-dialog modal-fullscreen-xl-down">
+                <div class="modal-content">
+                <div class="modal-header">
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>
+                <div class="modal-body">
+                </div>
+                </div>
+                </div>
+                </div>
+                HTML,
+            ],
+
+            [
+                Modal::FULLSCREEN_BELOW_XXL,
+                <<<HTML
+                <button type="button" data-bs-toggle="modal" aria-controls="w0-modal" data-bs-target="#w0-modal">Show</button>
+                <div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true">
+                <div class="modal-dialog modal-fullscreen-xxl-down">
+                <div class="modal-content">
+                <div class="modal-header">
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>
+                <div class="modal-body">
+                </div>
+                </div>
+                </div>
+                </div>
+                HTML,
+            ]
         ];
+    }
 
-        foreach ($fullscreen as $className) {
-            Modal::counter(0);
+    /**
+     * @dataProvider screenSizeDataProvider
+     * @param string $size
+     * @param string $exprected
+     * @return void
+     * @throws \Yiisoft\Definitions\Exception\CircularReferenceException
+     * @throws \Yiisoft\Definitions\Exception\InvalidConfigException
+     * @throws \Yiisoft\Definitions\Exception\NotInstantiableException
+     * @throws \Yiisoft\Factory\NotFoundException
+     */
+    public function testFullscreen(string $size, string $expected): void
+    {
+        $html = Modal::widget()
+            ->withToggleLabel('Show')
+            ->fullscreen($size)
+            ->begin();
+        $html .= Modal::end();
 
-            $html = Modal::widget()
-                ->fullscreen($className)
-                ->begin();
-            $html .= Modal::end();
 
-            $expected = <<<HTML
-            <button type="button" data-bs-toggle="modal" data-bs-target="#w0-modal">Show</button>
-            <div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true">
-            <div class="modal-dialog {$className}">
-            <div class="modal-content">
-            <div class="modal-header">
-            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>
-            <div class="modal-body">
-            </div>
-            </div>
-            </div>
-            </div>
-            HTML;
-
-            $this->assertEqualsHTML($expected, $html);
-        }
+        $this->assertEqualsHTML($expected, $html);
     }
 
     public function testCustomTag(): void
     {
-        Modal::counter(0);
-
         $html = Modal::widget()
+            ->withToggleLabel('Show')
             ->contentOptions([
                 'tag' => 'form',
                 'action' => '/',
@@ -520,7 +657,7 @@ HTML;
         $html .= Modal::end();
 
         $expected = <<<'HTML'
-        <button type="button" data-bs-toggle="modal" data-bs-target="#w0-modal">Show</button>
+        <button type="button" data-bs-toggle="modal" aria-controls="w0-modal" data-bs-target="#w0-modal">Show</button>
         <div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true" aria-labelledby="w0-modal-label">
         <div class="modal-dialog">
         <form class="modal-content" action="/">
@@ -542,15 +679,13 @@ HTML;
 
     public function testStaticBackdrop(): void
     {
-        Modal::counter(0);
-
         $html = Modal::widget()
             ->staticBackdrop()
             ->begin();
         $html .= Modal::end();
 
         $expected = <<<HTML
-        <button type="button" data-bs-toggle="modal" data-bs-target="#w0-modal">Show</button>
+        <button type="button" data-bs-toggle="modal" aria-controls="w0-modal" data-bs-target="#w0-modal">Show</button>
         <div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true" data-bs-backdrop="static">
         <div class="modal-dialog">
         <div class="modal-content">
@@ -568,15 +703,13 @@ HTML;
 
     public function testScrollingLongContent(): void
     {
-        Modal::counter(0);
-
         $html = Modal::widget()
             ->scrollable()
             ->begin();
         $html .= Modal::end();
 
         $expected = <<<HTML
-        <button type="button" data-bs-toggle="modal" data-bs-target="#w0-modal">Show</button>
+        <button type="button" data-bs-toggle="modal" aria-controls="w0-modal" data-bs-target="#w0-modal">Show</button>
         <div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true">
         <div class="modal-dialog modal-dialog-scrollable">
         <div class="modal-content">
@@ -594,15 +727,13 @@ HTML;
 
     public function testVerticallyCentered(): void
     {
-        Modal::counter(0);
-
         $html = Modal::widget()
             ->centered()
             ->begin();
         $html .= Modal::end();
 
         $expected = <<<HTML
-        <button type="button" data-bs-toggle="modal" data-bs-target="#w0-modal">Show</button>
+        <button type="button" data-bs-toggle="modal" aria-controls="w0-modal" data-bs-target="#w0-modal">Show</button>
         <div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true">
         <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content">
@@ -620,21 +751,59 @@ HTML;
 
     public function testManyTogglers(): void
     {
-        Modal::counter(0);
         $widget = Modal::widget();
 
-        $html = $widget->renderToggleButton();
-        $html .= $widget->renderToggleButton(['label' => 'New Label']);
-        $html .= $widget->renderToggleButton(['class' => 'btn btn-primary', 'label' => 'New Label 2']);
-        $html .= $widget->renderToggleButton(['tag' => 'a']);
-        $html .= $widget->renderToggleButton(['tag' => 'a', 'href' => '/']);
+        $html = $widget->renderToggle();
+        $html .= $widget->withToggleLabel('New Label')
+            ->renderToggle();
+        $html .= $widget->withToggleLabel('New Label 2')
+            ->withToggleOptions([
+                'class' => 'btn btn-primary',
+            ])
+            ->renderToggle();
+        $html .= $widget->withToggleOptions([
+            'tag' => 'a',
+        ])
+        ->renderToggle();
+        $html .= $widget->withToggleOptions([
+            'tag' => 'a',
+            'href' => '/',
+        ])
+        ->renderToggle();
 
         $expected = <<<HTML
-        <button type="button" data-bs-toggle="modal" data-bs-target="#w0-modal">Show</button>
-        <button type="button" data-bs-toggle="modal" data-bs-target="#w0-modal">New Label</button>
-        <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#w0-modal">New Label 2</button>
-        <a href="#w0-modal" data-bs-toggle="modal">Show</a>
-        <a href="/" data-bs-toggle="modal" data-bs-target="#w0-modal">Show</a>
+        <button type="button" data-bs-toggle="modal" aria-controls="w0-modal" data-bs-target="#w0-modal">Show</button>
+        <button type="button" data-bs-toggle="modal" aria-controls="w0-modal" data-bs-target="#w0-modal">New Label</button>
+        <button type="button" class="btn btn-primary" data-bs-toggle="modal" aria-controls="w0-modal" data-bs-target="#w0-modal">New Label 2</button>
+        <a href="#w0-modal" data-bs-toggle="modal" aria-controls="w0-modal" role="button">Show</a>
+        <a href="/" data-bs-toggle="modal" aria-controls="w0-modal" role="button" data-bs-target="#w0-modal">Show</a>
+        HTML;
+
+        $this->assertEqualsHTML($expected, $html);
+    }
+
+    public function testDialogOptions(): void
+    {
+        $html = Modal::widget()
+            ->centered()
+            ->dialogOptions([
+                'class' => 'bg-white',
+            ])
+            ->begin();
+        $html .= Modal::end();
+
+        $expected = <<<HTML
+        <button type="button" data-bs-toggle="modal" aria-controls="w0-modal" data-bs-target="#w0-modal">Show</button>
+        <div id="w0-modal" class="modal fade" role="dialog" tabindex="-1" aria-hidden="true">
+        <div class="bg-white modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+        <div class="modal-header">
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button></div>
+        <div class="modal-body">
+        </div>
+        </div>
+        </div>
+        </div>
         HTML;
 
         $this->assertEqualsHTML($expected, $html);

--- a/tests/NavBarTest.php
+++ b/tests/NavBarTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Yii\Bootstrap5\Tests;
 
+use Yiisoft\Yii\Bootstrap5\Collapse;
 use Yiisoft\Yii\Bootstrap5\Nav;
 use Yiisoft\Yii\Bootstrap5\NavBar;
 use Yiisoft\Yii\Bootstrap5\Offcanvas;
@@ -15,10 +16,15 @@ use Yiisoft\Yii\Bootstrap5\Offcanvas;
  */
 final class NavBarTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        NavBar::counter(0);
+    }
+
     public function testRender(): void
     {
-        NavBar::counter(0);
-
         $html = NavBar::widget()
             ->brandText('My Company')
             ->brandUrl('/')
@@ -32,8 +38,8 @@ final class NavBarTest extends TestCase
         <nav id="w0-navbar" class="navbar-inverse navbar-static-top navbar-frontend navbar navbar-expand-lg">
         <div class="container">
         <a class="navbar-brand" href="/">My Company</a>
-        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-navbar-collapse" aria-controls="w0-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
-        <div id="w0-navbar-collapse" class="collapse navbar-collapse">
+        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" aria-label="Toggle navigation" aria-controls="w1-collapse" data-bs-target="#w1-collapse" aria-expanded="false"><span class="navbar-toggler-icon"></span></button>
+        <div id="w1-collapse" class="collapse navbar-collapse">
         </div>
         </div>
         </nav>
@@ -43,8 +49,6 @@ final class NavBarTest extends TestCase
 
     public function testBrandImage(): void
     {
-        NavBar::counter(0);
-
         $html = NavBar::widget()
             ->brandImage('/images/test.jpg')
             ->brandUrl('/')
@@ -59,8 +63,6 @@ final class NavBarTest extends TestCase
 
     public function testbrandUrl(): void
     {
-        NavBar::counter(0);
-
         $html = NavBar::widget()
             ->brandText('Yii Framework')
             ->brandUrl('/index.php')
@@ -75,8 +77,6 @@ final class NavBarTest extends TestCase
 
     public function testBrandText(): void
     {
-        NavBar::counter(0);
-
         $html = NavBar::widget()
             ->brandText('Yii Framework')
             ->brandUrl('')
@@ -91,8 +91,6 @@ final class NavBarTest extends TestCase
 
     public function testBrandImageText(): void
     {
-        NavBar::counter(0);
-
         $html = NavBar::widget()
             ->brandText('Yii Framework')
             ->brandImage('/images/test.jpg')
@@ -107,8 +105,6 @@ final class NavBarTest extends TestCase
 
     public function testNavAndForm(): void
     {
-        NavBar::counter(0);
-
         $html = NavBar::widget()
             ->brandText('My Company')
             ->brandUrl('/')
@@ -140,11 +136,11 @@ final class NavBarTest extends TestCase
         <nav id="w0-navbar" class="navbar navbar-expand-lg">
         <div class="container">
         <a class="navbar-brand" href="/">My Company</a>
-        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-navbar-collapse" aria-controls="w0-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
-        <div id="w0-navbar-collapse" class="collapse navbar-collapse">
-        <ul id="w1-nav" class="mr-auto nav"><li class="nav-item"><a class="nav-link" href="#">Home</a></li>
+        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" aria-label="Toggle navigation" aria-controls="w1-collapse" data-bs-target="#w1-collapse" aria-expanded="false"><span class="navbar-toggler-icon"></span></button>
+        <div id="w1-collapse" class="collapse navbar-collapse">
+        <ul id="w2-nav" class="mr-auto nav"><li class="nav-item"><a class="nav-link" href="#">Home</a></li>
         <li class="nav-item"><a class="nav-link" href="#">Link</a></li>
-        <li class="dropdown nav-item"><a class="dropdown-toggle nav-link" href="#" data-bs-toggle="dropdown">Dropdown</a><ul id="w2-dropdown" class="dropdown-menu">
+        <li class="dropdown nav-item"><a class="dropdown-toggle nav-link" href="#" data-bs-toggle="dropdown">Dropdown</a><ul id="w3-dropdown" class="dropdown-menu">
         <li><a class="dropdown-item" href="#">Action</a></li>
         <li><a class="dropdown-item" href="#">Another action</a></li>
         <li><hr class="dropdown-divider"></li>
@@ -161,8 +157,6 @@ final class NavBarTest extends TestCase
 
     public function testCollapseOptions(): void
     {
-        NavBar::counter(0);
-
         $html = NavBar::widget()
             ->collapseOptions(['class' => 'testMe'])
             ->begin();
@@ -171,8 +165,8 @@ final class NavBarTest extends TestCase
         <nav id="w0-navbar" class="navbar navbar-expand-lg">
         <div class="container">
 
-        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-navbar-collapse" aria-controls="w0-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
-        <div id="w0-navbar-collapse" class="testMe collapse navbar-collapse">
+        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" aria-label="Toggle navigation" aria-controls="w1-collapse" data-bs-target="#w1-collapse" aria-expanded="false"><span class="navbar-toggler-icon"></span></button>
+        <div id="w1-collapse" class="testMe collapse navbar-collapse">
         </div>
         </div>
         </nav>
@@ -182,8 +176,6 @@ final class NavBarTest extends TestCase
 
     public function testBrandOptions(): void
     {
-        NavBar::counter(0);
-
         $html = NavBar::widget()
             ->brandText('My App')
             ->brandOptions(['class' => 'text-dark'])
@@ -193,8 +185,8 @@ final class NavBarTest extends TestCase
         <nav id="w0-navbar" class="navbar navbar-expand-lg">
         <div class="container">
         <a class="text-dark navbar-brand" href="/">My App</a>
-        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-navbar-collapse" aria-controls="w0-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
-        <div id="w0-navbar-collapse" class="collapse navbar-collapse">
+        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" aria-label="Toggle navigation" aria-controls="w1-collapse" data-bs-target="#w1-collapse" aria-expanded="false"><span class="navbar-toggler-icon"></span></button>
+        <div id="w1-collapse" class="collapse navbar-collapse">
         </div>
         </div>
         </nav>
@@ -204,8 +196,6 @@ final class NavBarTest extends TestCase
 
     public function testBrandImageAttributes(): void
     {
-        NavBar::counter(0);
-
         $html = NavBar::widget()
             ->brandImage('empty.gif')
             ->brandImageAttributes(['width' => 100, 'height' => 100])
@@ -215,8 +205,8 @@ final class NavBarTest extends TestCase
         <nav id="w0-navbar" class="navbar navbar-expand-lg">
         <div class="container">
         <a class="navbar-brand" href="/"><img src="empty.gif" width="100" height="100" alt></a>
-        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-navbar-collapse" aria-controls="w0-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
-        <div id="w0-navbar-collapse" class="collapse navbar-collapse">
+        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" aria-label="Toggle navigation" aria-controls="w1-collapse" data-bs-target="#w1-collapse" aria-expanded="false"><span class="navbar-toggler-icon"></span></button>
+        <div id="w1-collapse" class="collapse navbar-collapse">
         </div>
         </div>
         </nav>
@@ -226,8 +216,6 @@ final class NavBarTest extends TestCase
 
     public function testScreenReaderToggleText(): void
     {
-        NavBar::counter(0);
-
         $html = NavBar::widget()
             ->screenReaderToggleText('Toggler navigation')
             ->begin();
@@ -236,8 +224,8 @@ final class NavBarTest extends TestCase
         <nav id="w0-navbar" class="navbar navbar-expand-lg">
         <div class="container">
 
-        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-navbar-collapse" aria-controls="w0-navbar-collapse" aria-expanded="false" aria-label="Toggler navigation"><span class="navbar-toggler-icon"></span></button>
-        <div id="w0-navbar-collapse" class="collapse navbar-collapse">
+        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" aria-label="Toggler navigation" aria-controls="w1-collapse" data-bs-target="#w1-collapse" aria-expanded="false"><span class="navbar-toggler-icon"></span></button>
+        <div id="w1-collapse" class="collapse navbar-collapse">
         </div>
         </div>
         </nav>
@@ -247,18 +235,16 @@ final class NavBarTest extends TestCase
 
     public function testTogglerContent(): void
     {
-        NavBar::counter(0);
-
         $html = NavBar::widget()
-            ->togglerContent('<div class="navbar-toggler-icon"></div>')
+            ->withToggleLabel('<div class="navbar-toggler-icon"></div>')
             ->begin();
         $html .= NavBar::end();
         $expected = <<<'HTML'
         <nav id="w0-navbar" class="navbar navbar-expand-lg">
         <div class="container">
 
-        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-navbar-collapse" aria-controls="w0-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><div class="navbar-toggler-icon"></div></button>
-        <div id="w0-navbar-collapse" class="collapse navbar-collapse">
+        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" aria-label="Toggle navigation" aria-controls="w1-collapse" data-bs-target="#w1-collapse" aria-expanded="false"><div class="navbar-toggler-icon"></div></button>
+        <div id="w1-collapse" class="collapse navbar-collapse">
         </div>
         </div>
         </nav>
@@ -268,18 +254,16 @@ final class NavBarTest extends TestCase
 
     public function testTogglerOptions(): void
     {
-        NavBar::counter(0);
-
         $html = NavBar::widget()
-            ->togglerOptions(['class' => 'testMe'])
+            ->withToggleOptions(['class' => 'testMe'])
             ->begin();
         $html .= NavBar::end();
         $expected = <<<'HTML'
         <nav id="w0-navbar" class="navbar navbar-expand-lg">
         <div class="container">
 
-        <button type="button" class="testMe navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-navbar-collapse" aria-controls="w0-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
-        <div id="w0-navbar-collapse" class="collapse navbar-collapse">
+        <button type="button" class="testMe navbar-toggler" data-bs-toggle="collapse" aria-label="Toggle navigation" aria-controls="w1-collapse" data-bs-target="#w1-collapse" aria-expanded="false"><span class="navbar-toggler-icon"></span></button>
+        <div id="w1-collapse" class="collapse navbar-collapse">
         </div>
         </div>
         </nav>
@@ -289,8 +273,6 @@ final class NavBarTest extends TestCase
 
     public function testRenderInnerContainer(): void
     {
-        NavBar::counter(0);
-
         $html = NavBar::widget()
             ->withoutRenderInnerContainer()
             ->begin();
@@ -298,8 +280,8 @@ final class NavBarTest extends TestCase
         $expected = <<<'HTML'
         <nav id="w0-navbar" class="navbar navbar-expand-lg">
 
-        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-navbar-collapse" aria-controls="w0-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
-        <div id="w0-navbar-collapse" class="collapse navbar-collapse">
+        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" aria-label="Toggle navigation" aria-controls="w1-collapse" data-bs-target="#w1-collapse" aria-expanded="false"><span class="navbar-toggler-icon"></span></button>
+        <div id="w1-collapse" class="collapse navbar-collapse">
         </div>
         </nav>
         HTML;
@@ -308,8 +290,6 @@ final class NavBarTest extends TestCase
 
     public function testInnerContainerOptions(): void
     {
-        NavBar::counter(0);
-
         $html = NavBar::widget()
             ->innerContainerOptions(['class' => 'text-link'])
             ->begin();
@@ -318,8 +298,8 @@ final class NavBarTest extends TestCase
         <nav id="w0-navbar" class="navbar navbar-expand-lg">
         <div class="text-link">
 
-        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#w0-navbar-collapse" aria-controls="w0-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
-        <div id="w0-navbar-collapse" class="collapse navbar-collapse">
+        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" aria-label="Toggle navigation" aria-controls="w1-collapse" data-bs-target="#w1-collapse" aria-expanded="false"><span class="navbar-toggler-icon"></span></button>
+        <div id="w1-collapse" class="collapse navbar-collapse">
         </div>
         </div>
         </nav>
@@ -329,8 +309,6 @@ final class NavBarTest extends TestCase
 
     public function testWithoutCollapse(): void
     {
-        NavBar::counter(0);
-
         $html = NavBar::widget()
             ->brandText('My Company')
             ->expandSize(null)
@@ -369,60 +347,115 @@ final class NavBarTest extends TestCase
         $this->assertEqualsHTML($expected, $html);
     }
 
-    public function testExpandSize(): void
+    public static function expandSizeDataProvider(): array
     {
-        $sizes = [
-            NavBar::EXPAND_SM,
-            NavBar::EXPAND_MD,
-            NavBar::EXPAND_LG,
-            NavBar::EXPAND_XL,
-            NavBar::EXPAND_XXL,
+        return [
+            [
+                NavBar::EXPAND_SM,
+                <<<HTML
+                <nav id="expanded-navbar" class="navbar navbar-expand-sm">
+                <div class="container">
+                <button type="button" class="navbar-toggler" data-bs-toggle="collapse" aria-label="Toggle navigation" aria-controls="w0-collapse" data-bs-target="#w0-collapse" aria-expanded="false"><span class="navbar-toggler-icon"></span></button>
+                <div id="w0-collapse" class="collapse navbar-collapse">
+                </div>
+                </div>
+                </nav>
+                HTML,
+            ],
+
+            [
+                NavBar::EXPAND_MD,
+                <<<HTML
+                <nav id="expanded-navbar" class="navbar navbar-expand-md">
+                <div class="container">
+                <button type="button" class="navbar-toggler" data-bs-toggle="collapse" aria-label="Toggle navigation" aria-controls="w0-collapse" data-bs-target="#w0-collapse" aria-expanded="false"><span class="navbar-toggler-icon"></span></button>
+                <div id="w0-collapse" class="collapse navbar-collapse">
+                </div>
+                </div>
+                </nav>
+                HTML,
+            ],
+
+            [
+                NavBar::EXPAND_LG,
+                <<<HTML
+                <nav id="expanded-navbar" class="navbar navbar-expand-lg">
+                <div class="container">
+                <button type="button" class="navbar-toggler" data-bs-toggle="collapse" aria-label="Toggle navigation" aria-controls="w0-collapse" data-bs-target="#w0-collapse" aria-expanded="false"><span class="navbar-toggler-icon"></span></button>
+                <div id="w0-collapse" class="collapse navbar-collapse">
+                </div>
+                </div>
+                </nav>
+                HTML,
+            ],
+
+            [
+                NavBar::EXPAND_XL,
+                <<<HTML
+                <nav id="expanded-navbar" class="navbar navbar-expand-xl">
+                <div class="container">
+                <button type="button" class="navbar-toggler" data-bs-toggle="collapse" aria-label="Toggle navigation" aria-controls="w0-collapse" data-bs-target="#w0-collapse" aria-expanded="false"><span class="navbar-toggler-icon"></span></button>
+                <div id="w0-collapse" class="collapse navbar-collapse">
+                </div>
+                </div>
+                </nav>
+                HTML,
+            ],
+
+            [
+                NavBar::EXPAND_XXL,
+                <<<HTML
+                <nav id="expanded-navbar" class="navbar navbar-expand-xxl">
+                <div class="container">
+                <button type="button" class="navbar-toggler" data-bs-toggle="collapse" aria-label="Toggle navigation" aria-controls="w0-collapse" data-bs-target="#w0-collapse" aria-expanded="false"><span class="navbar-toggler-icon"></span></button>
+                <div id="w0-collapse" class="collapse navbar-collapse">
+                </div>
+                </div>
+                </nav>
+                HTML,
+            ],
         ];
+    }
 
-        $NavBar = NavBar::widget()->options([
-            'id' => 'expanded-navbar',
-        ]);
+    /**
+     * @dataProvider expandSizeDataProvider
+     * @return void
+     * @throws \Yiisoft\Definitions\Exception\CircularReferenceException
+     * @throws \Yiisoft\Definitions\Exception\InvalidConfigException
+     * @throws \Yiisoft\Definitions\Exception\NotInstantiableException
+     * @throws \Yiisoft\Factory\NotFoundException
+     */
+    public function testExpandSize(string $size, string $expected): void
+    {
+        $html = NavBar::widget()->options([
+                'id' => 'expanded-navbar',
+            ])
+            ->expandSize($size)
+            ->begin() . NavBar::end();
 
-        foreach ($sizes as $size) {
-            $html = $NavBar
-                    ->expandSize($size)
-                    ->begin() . NavBar::end();
-            $expected = <<<HTML
-            <nav id="expanded-navbar" class="navbar {$size}">
-            <div class="container">
-            <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#expanded-navbar-collapse" aria-controls="expanded-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
-            <div id="expanded-navbar-collapse" class="collapse navbar-collapse">
-            </div>
-            </div>
-            </nav>
-            HTML;
-
-            $this->assertEqualsHTML($expected, $html);
-        }
+        $this->assertEqualsHTML($expected, $html);
     }
 
     public function testOffcanvas(): void
     {
-        NavBar::counter(0);
-
         $offcanvas = Offcanvas::widget()->title('Navbar offcanvas title');
         $html = NavBar::widget()
-            ->offcanvas($offcanvas)
+            ->withWidget($offcanvas)
             ->expandSize(null)
             ->begin();
         $html .= '<p>Some content in navbar offcanvas</p>';
         $html .= NavBar::end();
 
         $expected = <<<'HTML'
-        <nav id="w1-navbar" class="navbar">
+        <nav id="w0-navbar" class="navbar">
         <div class="container">
-        <button type="button" class="navbar-toggler" data-bs-toggle="offcanvas" data-bs-target="#w0-offcanvas" aria-controls="w0-offcanvas" aria-expanded="false" aria-label="Toggle navigation">
+        <button type="button" class="navbar-toggler" data-bs-toggle="offcanvas" aria-label="Toggle navigation" aria-controls="w1-offcanvas" data-bs-target="#w1-offcanvas">
         <span class="navbar-toggler-icon"></span>
         </button>
-        <div id="w0-offcanvas" class="offcanvas offcanvas-start" tabindex="-1" aria-labelledby="w0-offcanvas-title">
+        <div id="w1-offcanvas" class="offcanvas offcanvas-start" tabindex="-1" aria-labelledby="w1-offcanvas-title">
         <header class="offcanvas-header">
-        <h5 id="w0-offcanvas-title" class="offcanvas-title">Navbar offcanvas title</h5>
-        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="offcanvas"></button>
+        <h5 id="w1-offcanvas-title" class="offcanvas-title">Navbar offcanvas title</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
         </header>
         <div class="offcanvas-body">
         <p>Some content in navbar offcanvas</p>
@@ -437,26 +470,24 @@ final class NavBarTest extends TestCase
 
     public function testExpandedOffcanvas(): void
     {
-        NavBar::counter(0);
-
         $offcanvas = Offcanvas::widget()->title('Navbar offcanvas title');
         $html = NavBar::widget()
-            ->offcanvas($offcanvas)
+            ->withWidget($offcanvas)
             ->expandSize(NavBar::EXPAND_XL)
             ->begin();
         $html .= '<p>Some content in navbar offcanvas</p>';
         $html .= NavBar::end();
 
         $expected = <<<'HTML'
-        <nav id="w1-navbar" class="navbar navbar-expand-xl">
+        <nav id="w0-navbar" class="navbar navbar-expand-xl">
         <div class="container">
-        <button type="button" class="navbar-toggler" data-bs-toggle="offcanvas" data-bs-target="#w0-offcanvas" aria-controls="w0-offcanvas" aria-expanded="false" aria-label="Toggle navigation">
+        <button type="button" class="navbar-toggler" data-bs-toggle="offcanvas" aria-label="Toggle navigation" aria-controls="w1-offcanvas" data-bs-target="#w1-offcanvas">
         <span class="navbar-toggler-icon"></span>
         </button>
-        <div id="w0-offcanvas" class="offcanvas offcanvas-start" tabindex="-1" aria-labelledby="w0-offcanvas-title">
+        <div id="w1-offcanvas" class="offcanvas offcanvas-start" tabindex="-1" aria-labelledby="w1-offcanvas-title">
         <header class="offcanvas-header">
-        <h5 id="w0-offcanvas-title" class="offcanvas-title">Navbar offcanvas title</h5>
-        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="offcanvas"></button>
+        <h5 id="w1-offcanvas-title" class="offcanvas-title">Navbar offcanvas title</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
         </header>
         <div class="offcanvas-body">
         <p>Some content in navbar offcanvas</p>
@@ -471,18 +502,18 @@ final class NavBarTest extends TestCase
 
     public function testCollapseExternalContent(): void
     {
-        NavBar::counter(0);
-
         $html = NavBar::widget()
             ->innerContainerOptions([
                 'class' => 'container-fluid',
             ])
-            ->togglerOptions([
+            ->withToggle(true)
+            ->withToggleOptions([
                 'data' => [
                     'bs-target' => '#navbarToggleExternalContent',
                 ],
                 'aria' => [
                     'controls' => 'navbarToggleExternalContent',
+                    'expanded' => 'false',
                 ],
             ])
             ->expandSize(null)
@@ -492,7 +523,7 @@ final class NavBarTest extends TestCase
         $expected = <<<'HTML'
         <nav id="w0-navbar" class="navbar">
         <div class="container-fluid">
-        <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#navbarToggleExternalContent" aria-controls="navbarToggleExternalContent" aria-expanded="false" aria-label="Toggle navigation">
+        <button type="button" class="navbar-toggler" data-bs-target="#navbarToggleExternalContent" aria-controls="navbarToggleExternalContent" aria-expanded="false" data-bs-toggle="collapse" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
         </button>
         </div>
@@ -502,38 +533,102 @@ final class NavBarTest extends TestCase
         $this->assertEqualsHTML($expected, $html);
     }
 
-    public function testColorTheme(): void
+    public static function colorThemeDataProvider(): array
     {
-        $themes = [
-            NavBar::THEME_LIGHT => [
-                'navbar-light',
-            ],
-            NavBar::THEME_DARK => [
-                'navbar-dark',
-            ],
-        ];
-
-        foreach ($themes as $theme => $classNames) {
-            foreach ($classNames as $class) {
-                $html = NavBar::widget()
-                    ->withTheme($theme)
-                    ->options([
-                        'id' => 'expanded-navbar',
-                    ])
-                    ->begin();
-                $html .= NavBar::end();
-                $expected = <<<HTML
-                <nav id="expanded-navbar" class="navbar navbar-expand-lg {$class}" data-bs-theme="{$theme}">
+        return [
+            [
+                NavBar::THEME_LIGHT,
+                <<<HTML
+                <nav id="expanded-navbar" class="navbar navbar-expand-lg navbar-light" data-bs-theme="light">
                 <div class="container">
-                <button type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#expanded-navbar-collapse" aria-controls="expanded-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
-                <div id="expanded-navbar-collapse" class="collapse navbar-collapse">
+                <button type="button" class="navbar-toggler" data-bs-toggle="collapse" aria-label="Toggle navigation" aria-controls="w0-collapse" data-bs-target="#w0-collapse" aria-expanded="false"><span class="navbar-toggler-icon"></span></button>
+                <div id="w0-collapse" class="collapse navbar-collapse">
                 </div>
                 </div>
                 </nav>
-                HTML;
+                HTML,
+            ],
 
-                $this->assertEqualsHTML($expected, $html);
-            }
-        }
+            [
+                NavBar::THEME_DARK,
+                <<<HTML
+                <nav id="expanded-navbar" class="navbar navbar-expand-lg navbar-dark" data-bs-theme="dark">
+                <div class="container">
+                <button type="button" class="navbar-toggler" data-bs-toggle="collapse" aria-label="Toggle navigation" aria-controls="w0-collapse" data-bs-target="#w0-collapse" aria-expanded="false"><span class="navbar-toggler-icon"></span></button>
+                <div id="w0-collapse" class="collapse navbar-collapse">
+                </div>
+                </div>
+                </nav>
+                HTML,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider colorThemeDataProvider
+     * @param string $theme
+     * @param string $expected
+     * @return void
+     * @throws \Yiisoft\Definitions\Exception\CircularReferenceException
+     * @throws \Yiisoft\Definitions\Exception\InvalidConfigException
+     * @throws \Yiisoft\Definitions\Exception\NotInstantiableException
+     * @throws \Yiisoft\Factory\NotFoundException
+     */
+    public function testColorTheme(string $theme, string $expected): void
+    {
+        $html = NavBar::widget()
+            ->withTheme($theme)
+            ->options([
+                'id' => 'expanded-navbar',
+            ])
+            ->begin();
+        $html .= NavBar::end();
+
+        $this->assertEqualsHTML($expected, $html);
+    }
+
+    public static function toggleWidgetDataProvider(): array
+    {
+        return [
+            [
+                Collapse::class,
+                '<button type="button" data-bs-toggle="collapse" aria-controls="w0-collapse" data-bs-target="#w0-collapse" aria-expanded="false"></button>',
+            ],
+
+            [
+                Offcanvas::class,
+                '<button type="button" data-bs-toggle="offcanvas" aria-controls="w0-offcanvas" data-bs-target="#w0-offcanvas"></button>',
+            ],
+
+            [
+                null,
+                <<<'HTML'
+                <button type="button" class="navbar-toggler" data-bs-toggle="collapse" aria-controls="w0-navbar" data-bs-target="#w0-navbar" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon">
+                </span>
+                </button>
+                HTML,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider toggleWidgetDataProvider
+     * @param Collapse|Offcanvas|null $widget
+     * @param string $expected
+     * @return void
+     */
+    public function testToggle(?string $widget, string $expected): void
+    {
+        $widget = $widget ? $widget::widget() : null;
+
+        $navBar = NavBar::widget()
+            ->withWidget($widget);
+
+        $this->assertEqualsHTML(
+            $expected,
+            $navBar->renderToggle()
+                ->render()
+        );
     }
 }

--- a/tests/OffcanvasTest.php
+++ b/tests/OffcanvasTest.php
@@ -4,14 +4,20 @@ declare(strict_types=1);
 
 namespace Yiisoft\Yii\Bootstrap5\Tests;
 
+use Yiisoft\Html\Html;
 use Yiisoft\Yii\Bootstrap5\Offcanvas;
 
 final class OffcanvasTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Offcanvas::counter(0);
+    }
+
     public function testRender(): void
     {
-        Offcanvas::counter(0);
-
         $html = Offcanvas::widget()
             ->title('Offcanvas title')
             ->begin();
@@ -22,7 +28,7 @@ final class OffcanvasTest extends TestCase
         <div id="w0-offcanvas" class="offcanvas offcanvas-start" tabindex="-1" aria-labelledby="w0-offcanvas-title">
         <header class="offcanvas-header">
         <h5 id="w0-offcanvas-title" class="offcanvas-title">Offcanvas title</h5>
-        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="offcanvas"></button>
+        <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
         </header>
         <div class="offcanvas-body">
         <p>Some content here</p>
@@ -35,8 +41,6 @@ final class OffcanvasTest extends TestCase
 
     public function testOptions(): void
     {
-        Offcanvas::counter(0);
-
         $html = Offcanvas::widget()
             ->options([
                 'class' => 'custom-class',
@@ -51,7 +55,7 @@ final class OffcanvasTest extends TestCase
         <div id="w0-offcanvas" class="custom-class offcanvas offcanvas-start" data-custom="custom-data" tabindex="-1" aria-labelledby="w0-offcanvas-title">
         <header class="offcanvas-header">
         <h5 id="w0-offcanvas-title" class="offcanvas-title">Offcanvas title</h5>
-        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="offcanvas"></button>
+        <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
         </header>
         <div class="offcanvas-body">
         <p>Some content here</p>
@@ -64,8 +68,6 @@ final class OffcanvasTest extends TestCase
 
     public function testHeaderOptions(): void
     {
-        Offcanvas::counter(0);
-
         $html = Offcanvas::widget()
             ->headerOptions([
                 'tag' => 'div',
@@ -81,7 +83,7 @@ final class OffcanvasTest extends TestCase
         <div id="w0-offcanvas" class="offcanvas offcanvas-start" tabindex="-1" aria-labelledby="w0-offcanvas-title">
         <div class="custom-class offcanvas-header" data-custom="custom-data">
         <h5 id="w0-offcanvas-title" class="offcanvas-title">Offcanvas title</h5>
-        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="offcanvas"></button>
+        <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
         </div>
         <div class="offcanvas-body">
         <p>Some content here</p>
@@ -94,8 +96,6 @@ final class OffcanvasTest extends TestCase
 
     public function testTitleOptions(): void
     {
-        Offcanvas::counter(0);
-
         $html = Offcanvas::widget()
             ->title('Offcanvas title')
             ->titleOptions([
@@ -110,7 +110,7 @@ final class OffcanvasTest extends TestCase
         <div id="w0-offcanvas" class="offcanvas offcanvas-start" tabindex="-1" aria-labelledby="w0-offcanvas-title">
         <header class="offcanvas-header">
         <h2 id="w0-offcanvas-title" class="h4 offcanvas-title">Offcanvas title</h2>
-        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="offcanvas"></button>
+        <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
         </header>
         <div class="offcanvas-body">
         <p>Some content here</p>
@@ -123,8 +123,6 @@ final class OffcanvasTest extends TestCase
 
     public function testBodyOptions(): void
     {
-        Offcanvas::counter(0);
-
         $html = Offcanvas::widget()
             ->title('Offcanvas title')
             ->bodyOptions([
@@ -139,7 +137,7 @@ final class OffcanvasTest extends TestCase
         <div id="w0-offcanvas" class="offcanvas offcanvas-start" tabindex="-1" aria-labelledby="w0-offcanvas-title">
         <header class="offcanvas-header">
         <h5 id="w0-offcanvas-title" class="offcanvas-title">Offcanvas title</h5>
-        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="offcanvas"></button>
+        <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
         </header>
         <div class="custom-body-class offcanvas-body" data-custom="custom-body-data">
         <p>Some content here</p>
@@ -152,8 +150,6 @@ final class OffcanvasTest extends TestCase
 
     public function testEmptyTitle(): void
     {
-        Offcanvas::counter(0);
-
         $html = Offcanvas::widget()
             ->title('')
             ->begin();
@@ -164,7 +160,7 @@ final class OffcanvasTest extends TestCase
         <div id="w0-offcanvas" class="offcanvas offcanvas-start" tabindex="-1">
         <header class="offcanvas-header">
         <h5 id="w0-offcanvas-title" class="offcanvas-title"></h5>
-        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="offcanvas"></button>
+        <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
         </header>
         <div class="offcanvas-body">
         <p>Some content here</p>
@@ -183,7 +179,7 @@ final class OffcanvasTest extends TestCase
         $expected = <<<'HTML'
         <div id="w0-offcanvas" class="offcanvas offcanvas-start" tabindex="-1">
         <header class="offcanvas-header">
-        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="offcanvas"></button>
+        <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
         </header>
         <div class="offcanvas-body">
         <p>Some content here</p>
@@ -194,42 +190,84 @@ final class OffcanvasTest extends TestCase
         $this->assertEqualsHTML($expected, $html);
     }
 
-    public function testPlacement(): void
+    public static function placementDataProvider(): array
     {
-        $placements = [
-            Offcanvas::PLACEMENT_TOP,
-            Offcanvas::PLACEMENT_END,
-            Offcanvas::PLACEMENT_BOTTOM,
-            Offcanvas::PLACEMENT_START,
+        return [
+            [
+                Offcanvas::PLACEMENT_TOP,
+                <<<'HTML'
+                <div id="offcanvas-placement" class="offcanvas offcanvas-top" tabindex="-1">
+                <header class="offcanvas-header">
+                <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+                </header>
+                <div class="offcanvas-body">
+                </div>
+                </div>
+                HTML,
+            ],
+
+            [
+                Offcanvas::PLACEMENT_BOTTOM,
+                <<<'HTML'
+                <div id="offcanvas-placement" class="offcanvas offcanvas-bottom" tabindex="-1">
+                <header class="offcanvas-header">
+                <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+                </header>
+                <div class="offcanvas-body">
+                </div>
+                </div>
+                HTML,
+            ],
+
+            [
+                Offcanvas::PLACEMENT_START,
+                <<<'HTML'
+                <div id="offcanvas-placement" class="offcanvas offcanvas-start" tabindex="-1">
+                <header class="offcanvas-header">
+                <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+                </header>
+                <div class="offcanvas-body">
+                </div>
+                </div>
+                HTML,
+            ],
+
+            [
+                Offcanvas::PLACEMENT_END,
+                <<<'HTML'
+                <div id="offcanvas-placement" class="offcanvas offcanvas-end" tabindex="-1">
+                <header class="offcanvas-header">
+                <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+                </header>
+                <div class="offcanvas-body">
+                </div>
+                </div>
+                HTML,
+            ],
         ];
+    }
 
-        $Offcanvas = Offcanvas::widget()->options([
-            'id' => 'offcanvas-placement',
-        ]);
+    /**
+     * @dataProvider placementDataProvider
+     * @return void
+     * @throws \Yiisoft\Definitions\Exception\CircularReferenceException
+     * @throws \Yiisoft\Definitions\Exception\InvalidConfigException
+     * @throws \Yiisoft\Definitions\Exception\NotInstantiableException
+     * @throws \Yiisoft\Factory\NotFoundException
+     */
+    public function testPlacement(string $placement, string $expected): void
+    {
+        $html = Offcanvas::widget()->options([
+                    'id' => 'offcanvas-placement',
+                ])
+                ->placement($placement)
+                ->begin() . Offcanvas::end();
 
-        foreach ($placements as $placement) {
-            $html = $Offcanvas
-                    ->placement($placement)
-                    ->begin() . Offcanvas::end();
-
-            $expected = <<<HTML
-            <div id="offcanvas-placement" class="offcanvas {$placement}" tabindex="-1">
-            <header class="offcanvas-header">
-            <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="offcanvas"></button>
-            </header>
-            <div class="offcanvas-body">
-            </div>
-            </div>
-            HTML;
-
-            $this->assertEqualsHTML($expected, $html);
-        }
+        $this->assertEqualsHTML($expected, $html);
     }
 
     public function testScroll(): void
     {
-        Offcanvas::counter(0);
-
         $html = Offcanvas::widget()
             ->title('Offcanvas title')
             ->scroll(true)
@@ -241,7 +279,7 @@ final class OffcanvasTest extends TestCase
         <div id="w0-offcanvas" class="offcanvas offcanvas-start" tabindex="-1" aria-labelledby="w0-offcanvas-title" data-bs-scroll="true">
         <header class="offcanvas-header">
         <h5 id="w0-offcanvas-title" class="offcanvas-title">Offcanvas title</h5>
-        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="offcanvas"></button>
+        <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
         </header>
         <div class="offcanvas-body">
         <p>Some content here</p>
@@ -254,8 +292,6 @@ final class OffcanvasTest extends TestCase
 
     public function testBackdrop(): void
     {
-        Offcanvas::counter(0);
-
         $html = Offcanvas::widget()
             ->title('Offcanvas title')
             ->withoutBackdrop()
@@ -267,7 +303,7 @@ final class OffcanvasTest extends TestCase
         <div id="w0-offcanvas" class="offcanvas offcanvas-start" tabindex="-1" aria-labelledby="w0-offcanvas-title" data-bs-backdrop="false">
         <header class="offcanvas-header">
         <h5 id="w0-offcanvas-title" class="offcanvas-title">Offcanvas title</h5>
-        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="offcanvas"></button>
+        <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
         </header>
         <div class="offcanvas-body">
         <p>Some content here</p>
@@ -294,7 +330,7 @@ final class OffcanvasTest extends TestCase
         <div id="w0-offcanvas" class="offcanvas offcanvas-start" tabindex="-1" aria-labelledby="w0-offcanvas-title" data-bs-backdrop="false" data-bs-theme="dark">
         <header class="offcanvas-header">
         <h5 id="w0-offcanvas-title" class="offcanvas-title">Offcanvas title</h5>
-        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="offcanvas"></button>
+        <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
         </header>
         <div class="offcanvas-body">
         <p>Some content here</p>
@@ -319,7 +355,105 @@ final class OffcanvasTest extends TestCase
         <div id="w0-offcanvas" class="offcanvas offcanvas-start" tabindex="-1" aria-labelledby="w0-offcanvas-title" data-bs-backdrop="false" data-bs-theme="red">
         <header class="offcanvas-header">
         <h5 id="w0-offcanvas-title" class="offcanvas-title">Offcanvas title</h5>
-        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="offcanvas"></button>
+        <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+        </header>
+        <div class="offcanvas-body">
+        <p>Some content here</p>
+        </div>
+        </div>
+        HTML;
+
+        $this->assertEqualsHTML($expected, $html);
+    }
+
+    public function testWithToggle(): void
+    {
+        Offcanvas::counter(0);
+
+        $html = Offcanvas::widget()
+            ->title('Offcanvas title')
+            ->withTheme('red')
+            ->withoutBackdrop()
+            ->withToggle(true)
+            ->begin();
+        $html .= '<p>Some content here</p>';
+        $html .= Offcanvas::end();
+
+        $expected = <<<'HTML'
+        <button type="button" data-bs-toggle="offcanvas" aria-controls="w0-offcanvas" data-bs-target="#w0-offcanvas"></button>
+        <div id="w0-offcanvas" class="offcanvas offcanvas-start" tabindex="-1" aria-labelledby="w0-offcanvas-title" data-bs-backdrop="false" data-bs-theme="red">
+        <header class="offcanvas-header">
+        <h5 id="w0-offcanvas-title" class="offcanvas-title">Offcanvas title</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+        </header>
+        <div class="offcanvas-body">
+        <p>Some content here</p>
+        </div>
+        </div>
+        HTML;
+
+        $this->assertEqualsHTML($expected, $html);
+    }
+
+    public function testCloseButton(): void
+    {
+        $html = Offcanvas::widget()
+            ->title('Offcanvas title')
+            ->withTheme('red')
+            ->withoutBackdrop()
+            ->withToggle(true)
+            ->withCloseButtonOptions([
+                'class' => [
+                    'widget' => 'test_class',
+                ],
+            ])
+            ->withCloseButtonLabel('Close button label')
+            ->begin();
+        $html .= '<p>Some content here</p>';
+        $html .= Offcanvas::end();
+
+        $expected = <<<'HTML'
+        <button type="button" data-bs-toggle="offcanvas" aria-controls="w0-offcanvas" data-bs-target="#w0-offcanvas"></button>
+        <div id="w0-offcanvas" class="offcanvas offcanvas-start" tabindex="-1" aria-labelledby="w0-offcanvas-title" data-bs-backdrop="false" data-bs-theme="red">
+        <header class="offcanvas-header">
+        <h5 id="w0-offcanvas-title" class="offcanvas-title">Offcanvas title</h5>
+        <button type="button" class="test_class" data-bs-dismiss="offcanvas">Close button label</button>
+        </header>
+        <div class="offcanvas-body">
+        <p>Some content here</p>
+        </div>
+        </div>
+        HTML;
+
+        $this->assertEqualsHTML($expected, $html);
+    }
+
+    public function testCloseButtonEncode(): void
+    {
+        $html = Offcanvas::widget()
+            ->title('Offcanvas title')
+            ->withTheme('red')
+            ->withoutBackdrop()
+            ->withToggle(true)
+            ->withCloseButtonOptions([
+                'class' => [
+                    'widget' => '',
+                ],
+            ])
+            ->withCloseButtonLabel(Html::img('close.png', 'Close'))
+            ->withEncodeCloseButton(false)
+            ->begin();
+        $html .= '<p>Some content here</p>';
+        $html .= Offcanvas::end();
+
+        $expected = <<<'HTML'
+        <button type="button" data-bs-toggle="offcanvas" aria-controls="w0-offcanvas" data-bs-target="#w0-offcanvas"></button>
+        <div id="w0-offcanvas" class="offcanvas offcanvas-start" tabindex="-1" aria-labelledby="w0-offcanvas-title" data-bs-backdrop="false" data-bs-theme="red">
+        <header class="offcanvas-header">
+        <h5 id="w0-offcanvas-title" class="offcanvas-title">Offcanvas title</h5>
+        <button type="button" class data-bs-dismiss="offcanvas">
+        <img src="close.png" alt="Close">
+        </button>
         </header>
         <div class="offcanvas-body">
         <p>Some content here</p>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️

1. New `Collapse` widget
2. New `AbstractToggleWidget` for widgets with toggler
3. New `AbstractCloseButtonWidget` for widgets with optional close button
4. `Accordion` and `NavBar` now using `Collapse` instead of generate html tags
5. Replace `NavBar::offcanvas(?Offcanvas $offcanvas)` to `NavBar::withWidget(Offcanvas|Collapse|null $widget)`
6. `Collapse` and `NavBar` now extended from `AbstractToggleWidget`
7. `Modal` and `Offcanvas` now extended from `AbstractCloseButtonWidget`
