### PR TITLE
Close button trait

### DIFF
--- a/src/Accordion.php
+++ b/src/Accordion.php
@@ -9,7 +9,6 @@ use RuntimeException;
 use Stringable;
 use Yiisoft\Arrays\ArrayHelper;
 use Yiisoft\Html\Html;
-
 use function array_key_exists;
 use function implode;
 use function is_array;
@@ -84,6 +83,7 @@ final class Accordion extends Widget
     private bool $encodeLabels = true;
     private bool $encodeTags = false;
     private bool $autoCloseItems = true;
+    private array $itemOptions = [];
     private array $headerOptions = [];
     private array $toggleOptions = [];
     private array $contentOptions = [];
@@ -202,6 +202,14 @@ final class Accordion extends Widget
         return $new;
     }
 
+    public function withItemOptions(array $options): self
+    {
+        $new = clone $this;
+        $new->itemOptions = $options;
+
+        return $new;
+    }
+
     /**
      * Options for each header if not present in item
      */
@@ -306,12 +314,13 @@ final class Accordion extends Widget
                 throw new RuntimeException('The "label" option is required.');
             }
 
-            $options = ArrayHelper::getValue($item, 'options', []);
+            $options = ArrayHelper::getValue($item, 'options', $this->itemOptions);
+            $tag = ArrayHelper::remove($options, 'tag', 'div');
             $item = $this->renderItem($item);
 
             Html::addCssClass($options, ['panel' => 'accordion-item']);
 
-            $items[] = Html::div($item, $options)
+            $items[] = Html::tag($tag, $item, $options)
                 ->encode(false)
                 ->render();
 

--- a/src/CloseButtonTrait.php
+++ b/src/CloseButtonTrait.php
@@ -9,18 +9,24 @@ use Yiisoft\Arrays\ArrayHelper;
 use Yiisoft\Html\Html;
 use Yiisoft\Html\Tag\Base\Tag;
 
-abstract class AbstractCloseButtonWidget extends AbstractToggleWidget
+trait CloseButtonTrait
 {
-    protected ?array $closeButtonOptions = [];
-    protected string|Stringable $closeButtonLabel = '';
-    protected bool $encodeCloseButton = true;
+    private array $closeButtonOptions = [];
+    private string|Stringable $closeButtonLabel = '';
+    private bool $encodeCloseButton = true;
+    private bool $showCloseButton = true;
+
+
+    abstract protected function toggleComponent(): string;
+
+    abstract public function getId(): ?string;
 
     /**
      * The HTML attributes for the widget close button tag. The following special options are recognized.
      *
      * {@see Html::renderTagAttributes()} for details on how attributes are being rendered.
      */
-    public function withCloseButtonOptions(?array $options): static
+    public function withCloseButtonOptions(array $options): static
     {
         $new = clone $this;
         $new->closeButtonOptions = $options;
@@ -33,7 +39,18 @@ abstract class AbstractCloseButtonWidget extends AbstractToggleWidget
      */
     public function withoutCloseButton(): static
     {
-        return $this->withCloseButtonOptions(null);
+        $new = clone $this;
+        $new->showCloseButton = false;
+
+        return $new;
+    }
+
+    public function withCloseButton(): static
+    {
+        $new = clone $this;
+        $new->showCloseButton = true;
+
+        return $new;
     }
 
     public function withCloseButtonLabel(string|Stringable $label): static
@@ -52,20 +69,23 @@ abstract class AbstractCloseButtonWidget extends AbstractToggleWidget
         return $new;
     }
 
-    public function renderCloseButton(): ?Tag
+    public function renderCloseButton(bool $inside = false): ?Tag
     {
-        $options = $this->closeButtonOptions;
-
-        if ($options === null) {
+        if ($inside && $this->showCloseButton === false) {
             return null;
         }
 
+        $options = $this->closeButtonOptions;
         $tagName = ArrayHelper::remove($options, 'tag', 'button');
 
         Html::addCssClass($options, ['widget' => 'btn-close']);
 
         $label = (string) $this->closeButtonLabel;
         $options['data-bs-dismiss'] = $this->toggleComponent();
+
+        if (!$inside) {
+            $options['data-bs-target'] = '#' . $this->getId();
+        }
 
         if (empty($label) && !isset($options['aria-label']) && !isset($options['aria']['label'])) {
             $options['aria-label'] = 'Close';

--- a/src/Collapse.php
+++ b/src/Collapse.php
@@ -7,7 +7,6 @@ namespace Yiisoft\Yii\Bootstrap5;
 use Stringable;
 use Yiisoft\Arrays\ArrayHelper;
 use Yiisoft\Html\Html;
-
 use function array_key_exists;
 
 /**
@@ -61,8 +60,8 @@ final class Collapse extends AbstractToggleWidget
         $new = clone $this;
         $new->bodyOptions = $options;
 
-        if (!array_key_exists('tag', $this->bodyOptions)) {
-            $this->bodyOptions['tag'] = 'div';
+        if (!array_key_exists('tag', $options)) {
+            $new->bodyOptions['tag'] = 'div';
         }
 
         return $new;

--- a/src/Modal.php
+++ b/src/Modal.php
@@ -8,7 +8,6 @@ use JsonException;
 use Stringable;
 use Yiisoft\Arrays\ArrayHelper;
 use Yiisoft\Html\Html;
-
 use function array_merge;
 
 /**
@@ -28,8 +27,10 @@ use function array_merge;
  * echo Modal::end();
  * ```
  */
-final class Modal extends AbstractCloseButtonWidget
+final class Modal extends AbstractToggleWidget
 {
+    use CloseButtonTrait;
+
     /**
      * Size classes
      */
@@ -382,7 +383,7 @@ final class Modal extends AbstractCloseButtonWidget
     private function renderHeader(): string
     {
         $title = (string) $this->renderTitle();
-        $button = (string) $this->renderCloseButton();
+        $button = (string) $this->renderCloseButton(true);
 
         if ($button === '' && $title === '') {
             return '';

--- a/src/Offcanvas.php
+++ b/src/Offcanvas.php
@@ -7,8 +7,10 @@ namespace Yiisoft\Yii\Bootstrap5;
 use Yiisoft\Arrays\ArrayHelper;
 use Yiisoft\Html\Html;
 
-final class Offcanvas extends AbstractCloseButtonWidget
+final class Offcanvas extends AbstractToggleWidget
 {
+    use CloseButtonTrait;
+
     public const PLACEMENT_TOP = 'offcanvas-top';
     public const PLACEMENT_END = 'offcanvas-end';
     public const PLACEMENT_BOTTOM = 'offcanvas-bottom';
@@ -200,7 +202,7 @@ final class Offcanvas extends AbstractCloseButtonWidget
         Html::addCssClass($options, ['widget' => 'offcanvas-header']);
 
         $title = (string) $this->renderTitle();
-        $closeButton = $this->renderCloseButton();
+        $closeButton = $this->renderCloseButton(true);
 
         return Html::tag($tag, $title . $closeButton, $options)
             ->encode(false)

--- a/tests/AccordionTest.php
+++ b/tests/AccordionTest.php
@@ -829,4 +829,65 @@ HTML_WRAP;
         HTML;
         $this->assertEqualsHTML($expected, $html);
     }
+
+    public function testItemOptions(): void
+    {
+        $items = [
+            [
+                'label' => 'Caption 1',
+                'content' => 'Table rows 1',
+            ],
+            [
+                'label' => 'Caption 2',
+                'content' => 'Table rows 2',
+                'contentOptions' => [
+                    'tag' => 'tbody',
+                    'class' => [
+                        'bg-success',
+                    ],
+                ],
+            ],
+        ];
+
+        $html = Accordion::widget()
+            ->items($items)
+            ->defaultExpand(false)
+            ->withItemOptions([
+                'tag' => 'table',
+            ])
+            ->headerOptions([
+                'tag' => 'caption',
+            ])
+            ->contentOptions([
+                'tag' => 'tbody',
+            ])
+            ->bodyOptions([
+                'tag' => null,
+            ])
+            ->render();
+        $expected = <<<'HTML'
+        <div id="w0-accordion" class="accordion">
+
+        <table class="accordion-item">
+        <caption class="accordion-header">
+        <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-controls="w1-collapse" data-bs-target="#w1-collapse" aria-expanded="false">Caption 1</button>
+        </caption>
+        <tbody id="w1-collapse" class="accordion-collapse collapse" data-bs-parent="#w0-accordion">
+        Table rows 1
+        </tbody>
+        </table>
+
+        <table class="accordion-item">
+        <caption class="accordion-header">
+        <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" aria-controls="w2-collapse" data-bs-target="#w2-collapse" aria-expanded="false">Caption 2</button>
+        </caption>
+        <tbody id="w2-collapse" class="bg-success accordion-collapse collapse" data-bs-parent="#w0-accordion">
+        Table rows 2
+        </tbody>
+        </table>
+
+        </div>
+        HTML;
+        $this->assertEqualsHTML($expected, $html);
+    }
 }

--- a/tests/AlertTest.php
+++ b/tests/AlertTest.php
@@ -70,7 +70,7 @@ final class AlertTest extends TestCase
             ->render();
         $expected = <<<'HTML'
         <div id="w0-alert" class="alert-warning alert alert-dismissible" role="alert"><strong>Holy guacamole!</strong> You should check in on some of those fields below.
-        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="alert"></button>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
         </div>
         HTML;
         $this->assertEqualsHTML($expected, $html);
@@ -91,7 +91,7 @@ final class AlertTest extends TestCase
             ->render();
         $expected = <<<'HTML'
         <div id="w0-alert" class="alert-warning alert alert-dismissible" role="alert">A simple primary alert with <a href="#" class="alert-link">an example link</a>. Give it a click if you like.
-        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="alert"></button>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
         </div>
         HTML;
         $this->assertEqualsHTML($expected, $html);
@@ -117,7 +117,7 @@ final class AlertTest extends TestCase
             ->render();
         $expected = <<<'HTML'
         <div id="w0-alert" class="alert-warning d-flex align-items-center alert alert-dismissible" role="alert"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-exclamation-triangle-fill flex-shrink-0 me-2" viewBox="0 0 16 16"><path d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5zm.002 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2z"/></svg><div>An example alert with an icon</div>
-        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="alert"></button>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
         </div>
         HTML;
         $this->assertEqualsHTML($expected, $html);
@@ -135,7 +135,7 @@ final class AlertTest extends TestCase
             ->render();
         $expected = <<<'HTML'
         <div id="w0-alert" class="alert alert-dismissible" role="alert">Message1
-        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="alert"></button>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
         </div>
         HTML;
         $this->assertEqualsHTML($expected, $html);
@@ -163,11 +163,11 @@ final class AlertTest extends TestCase
 
         $html = Alert::widget()
             ->body('Message1')
-            ->closeButton(['class' => 'btn-lg'])
+            ->withCloseButtonOptions(['class' => 'btn-lg'])
             ->render();
         $expected = <<<'HTML'
         <div id="w0-alert" class="alert alert-dismissible" role="alert">Message1
-        <button type="button" class="btn-lg" aria-label="Close" data-bs-dismiss="alert"></button>
+        <button type="button" class="btn-lg btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
         </div>
         HTML;
         $this->assertEqualsHTML($expected, $html);
@@ -176,15 +176,14 @@ final class AlertTest extends TestCase
 
         $html = Alert::widget()
             ->body('Message1')
-            ->closeButtonTag('a')
-            ->closeButton([
-                'class' => 'btn-close',
+            ->withCloseButtonOptions([
+                'tag' => 'a',
                 'href' => '/',
             ])
             ->render();
         $expected = <<<'HTML'
         <div id="w0-alert" class="alert alert-dismissible" role="alert">Message1
-        <a class="btn-close" href="/" aria-label="Close" data-bs-dismiss="alert"></a>
+        <a class="btn-close" href="/" data-bs-dismiss="alert" aria-label="Close" role="button"></a>
         </div>
         HTML;
         $this->assertEqualsHTML($expected, $html);
@@ -200,7 +199,7 @@ final class AlertTest extends TestCase
             ->render();
         $expected = <<<'HTML'
         <div id="w0-alert" class="alert alert-dismissible fade show" role="alert">Message1
-        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="alert"></button>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
         </div>
         HTML;
         $this->assertEqualsHTML($expected, $html);
@@ -244,8 +243,48 @@ final class AlertTest extends TestCase
         <div id="w0-alert" class="alert alert-dismissible fade show" role="alert">
         <h5 class="header-class alert-heading">Alert header</h5>
         Message1
-        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="alert"></button>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
         </div>
+        HTML;
+
+        $this->assertEqualsHTML($expected, $html);
+    }
+
+    public function testOutsideCloseButton(): void
+    {
+        Alert::counter(0);
+
+        $widget = Alert::widget()
+            ->withCloseButton()
+            ->body('Message1');
+
+        $html = $widget->render();
+        $html .= $widget->renderCloseButton();
+
+        $expected = <<<'HTML'
+        <div id="w0-alert" class="alert alert-dismissible" role="alert">
+        Message1
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" data-bs-target="#w0-alert" aria-label="Close"></button>
+        HTML;
+
+        $this->assertEqualsHTML($expected, $html);
+
+        Alert::counter(0);
+
+        $widget = Alert::widget()
+            ->withoutCloseButton()
+            ->body('Message2');
+
+        $html = $widget->render();
+        $html .= $widget->renderCloseButton();
+
+        $expected = <<<'HTML'
+        <div id="w0-alert" class="alert" role="alert">
+        Message2
+        </div>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" data-bs-target="#w0-alert" aria-label="Close"></button>
         HTML;
 
         $this->assertEqualsHTML($expected, $html);

--- a/tests/ModalTest.php
+++ b/tests/ModalTest.php
@@ -48,6 +48,8 @@ HTML;
 
     public function testFooter(): void
     {
+        Modal::counter(0);
+
         $widget = Modal::widget()
             ->withToggleLabel('Show');
         $modal = $widget->footer(
@@ -58,7 +60,7 @@ HTML;
                 ],
             ])
             ->withCloseButtonLabel('Close')
-            ->renderCloseButton() . "\n" .
+            ->renderCloseButton(true) . "\n" .
             Html::button(
                 'Save changes',
                 [

--- a/tests/ToastTest.php
+++ b/tests/ToastTest.php
@@ -25,9 +25,7 @@ final class ToastTest extends TestCase
         <div id="w0-toast" class="toast" role="alert" aria-live="assertive" aria-atomic="true">
         <div class="toast-header">
         <strong class="me-auto"></strong>
-        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="toast">
-        <span aria-hidden="true">&times;</span>
-        </button>
+        <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
         </div>
         <div class="toast-body test" style="text-align: center;">
         </div></div>
@@ -53,9 +51,7 @@ final class ToastTest extends TestCase
         <div class="toast-header">
         <strong class="me-auto">Toast title</strong>
         <small>a minute ago</small>
-        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="toast">
-        <span aria-hidden="true">&times;</span>
-        </button>
+        <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
         </div>
         <div class="toast-body">Woohoo, you're reading this text in a toast!
         </div></div>
@@ -81,9 +77,7 @@ final class ToastTest extends TestCase
         <div class="toast-header">
         <strong class="me-auto">Toast title</strong>
         <small class="toast-date-time" style="text-align: right;">a minute ago</small>
-        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="toast">
-        <span aria-hidden="true">&times;</span>
-        </button>
+        <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
         </div>
         <div class="toast-body">
         </div></div>
@@ -107,9 +101,7 @@ final class ToastTest extends TestCase
         <div id="w0-toast" class="toast" role="alert" aria-live="assertive" aria-atomic="true">
         <div class="toast-header">
         <h5 class="me-auto" style="text-align: left;">Toast title</h5>
-        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="toast">
-        <span aria-hidden="true">&times;</span>
-        </button>
+        <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
         </div>
         <div class="toast-body">
         </div></div>
@@ -122,7 +114,7 @@ final class ToastTest extends TestCase
         Toast::counter(0);
 
         $html = Toast::widget()
-            ->closeButton(['class' => 'btn-lg'])
+            ->withCloseButtonOptions(['class' => 'btn-lg'])
             ->title('Toast title')
             ->headerOptions(['class' => 'text-dark'])
             ->begin();
@@ -131,9 +123,7 @@ final class ToastTest extends TestCase
         <div id="w0-toast" class="toast" role="alert" aria-live="assertive" aria-atomic="true">
         <div class="text-dark toast-header">
         <strong class="me-auto">Toast title</strong>
-        <button type="button" class="btn-lg" aria-label="Close" data-bs-dismiss="toast">
-        <span aria-hidden="true">&times;</span>
-        </button>
+        <button type="button" class="btn-lg btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
         </div>
         <div class="toast-body">
         </div></div>
@@ -158,9 +148,7 @@ final class ToastTest extends TestCase
         <div id="w0-toast" class="toast" role="alert" aria-live="assertive" aria-atomic="true">
         <div class="text-dark toast-header">
         <h5 class="me-auto" style="text-align: left;">Toast title</h5>
-        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="toast">
-        <span aria-hidden="true">&times;</span>
-        </button>
+        <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
         </div>
         <div class="toast-body">
         </div></div>
@@ -186,9 +174,7 @@ final class ToastTest extends TestCase
         <div id="t0-toast" class="text-danger toast" role="alert" aria-live="assertive" aria-atomic="true">
         <div class="toast-header">
         <h5 class="me-auto" style="text-align: left;">Toast title</h5>
-        <button type="button" class="btn-close" aria-label="Close" data-bs-dismiss="toast">
-        <span aria-hidden="true">&times;</span>
-        </button>
+        <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
         </div>
         <div class="toast-body">
         </div></div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️

Since last PR I forgot about `Alert` and `Toast`, which have a close button but no toggle, so`AbstractCloseButton` moved to `CloseButtonTrait`.

1. `Offcanvas` and `Modal` now extended from `AbstractToggleWidget`
2. `Offcanvas`, `Modal`, `Alert` and `Toast` now use `CloseButtonTrait`
