### PR TITLE
Fix error typo in `testIdWithNull` to `testIdWithFalse`.

### DIFF
--- a/src/Alert.php
+++ b/src/Alert.php
@@ -256,7 +256,7 @@ final class Alert extends \Yiisoft\Widget\Widget
         $attributes = $this->attributes;
         $attributes['role'] = self::NAME;
         $content = '';
-        $id = is_string($this->id) ? $this->id : null;
+        $id = is_string($this->id) && $this->id !== '' ? $this->id : null;
         $toggle = '';
         $classes = $attributes['class'] ?? null;
         unset($attributes['class']);

--- a/tests/AlertTest.php
+++ b/tests/AlertTest.php
@@ -166,6 +166,18 @@ final class AlertTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    public function testIdWithEmpty(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div class="alert alert-secondary" role="alert">
+            Body
+            </div>
+            HTML,
+            Alert::widget()->id('')->body('Body')->render(),
+        );
+    }
+
     public function testIdWithFalse(): void
     {
         Assert::equalsWithoutLE(

--- a/tests/AlertTest.php
+++ b/tests/AlertTest.php
@@ -166,7 +166,7 @@ final class AlertTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testIdWithNull(): void
+    public function testIdWithFalse(): void
     {
         Assert::equalsWithoutLE(
             <<<HTML


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
