### PR TITLE
Handle rendering of `Accordion` widget when no items are provided.

### DIFF
--- a/src/Accordion.php
+++ b/src/Accordion.php
@@ -287,6 +287,10 @@ final class Accordion extends \Yiisoft\Widget\Widget
 
         unset($attributes['class']);
 
+        if ($this->items === []) {
+            return '';
+        }
+
         /** @psalm-var non-empty-string $id */
         $id = match ($this->id) {
             true => $attributes['id'] ?? Html::generateId(self::NAME . '-'),

--- a/tests/AccordionTest.php
+++ b/tests/AccordionTest.php
@@ -975,4 +975,9 @@ final class AccordionTest extends \PHPUnit\Framework\TestCase
                 ->render(),
         );
     }
+
+    public function testRenderWithEmptyItems(): void
+    {
+        $this->assertEmpty(Accordion::widget()->render());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
