### PR TITLE
Add customizable close button for `Alert` widget.

### DIFF
--- a/src/Alert.php
+++ b/src/Alert.php
@@ -10,6 +10,7 @@ use Yiisoft\Html\Html;
 use Yiisoft\Html\Tag\Button;
 use Yiisoft\Html\Tag\Div;
 
+use function array_key_exists;
 use function array_merge;
 use function array_filter;
 use function preg_replace;

--- a/src/Alert.php
+++ b/src/Alert.php
@@ -34,6 +34,8 @@ final class Alert extends \Yiisoft\Widget\Widget
     private string|Stringable $body = '';
     private array $cssClass = [];
     private array $closeButtonAttributes = [];
+    private string|null $closeButtonTag = null;
+    private string $closeButtonLabel = '';
     private bool $dismissable = false;
     private bool $fade = false;
     private string|null $header = null;
@@ -179,6 +181,36 @@ final class Alert extends \Yiisoft\Widget\Widget
     {
         $new = clone $this;
         $new->closeButtonAttributes = $value;
+
+        return $new;
+    }
+
+    /**
+     * Sets the label for the close button.
+     *
+     * @param string $value The label for the close button.
+     *
+     * @return self A new instance with the specified close button label.
+     */
+    public function closeButtonLabel(string $value): self
+    {
+        $new = clone $this;
+        $new->closeButtonLabel = $value;
+
+        return $new;
+    }
+
+    /**
+     * Sets the HTML tag to be used for the close button.
+     *
+     * @param string $value The HTML tag name for the close button.
+     *
+     * @return self A new instance with the specified close button tag.
+     */
+    public function closeButtonTag(string $value): self
+    {
+        $new = clone $this;
+        $new->closeButtonTag = $value;
 
         return $new;
     }
@@ -397,13 +429,19 @@ final class Alert extends \Yiisoft\Widget\Widget
      */
     private function renderToggle(): string
     {
+        $buttonTag = match ($this->closeButtonTag) {
+            null => Button::button(''),
+            '' => throw new InvalidArgumentException('Button tag cannot be empty string.'),
+            default => Html::tag($this->closeButtonTag),
+        };
+
         $closeButtonAttributes = $this->closeButtonAttributes;
 
-        $closeButtonAttributes['data-bs-dismiss'] = self::NAME;
-        $closeButtonAttributes['aria-label'] = 'Close';
+        $closeButtonAttributes['data-bs-dismiss'] ??= self::NAME;
+        $closeButtonAttributes['aria-label'] ??= 'Close';
 
         Html::addCssClass($closeButtonAttributes, 'btn-close');
 
-        return Button::button('')->addAttributes($closeButtonAttributes)->render();
+        return $buttonTag->addAttributes($closeButtonAttributes)->addContent($this->closeButtonLabel)->render();
     }
 }

--- a/src/Alert.php
+++ b/src/Alert.php
@@ -437,8 +437,13 @@ final class Alert extends \Yiisoft\Widget\Widget
 
         $closeButtonAttributes = $this->closeButtonAttributes;
 
-        $closeButtonAttributes['data-bs-dismiss'] ??= self::NAME;
-        $closeButtonAttributes['aria-label'] ??= 'Close';
+        if (array_key_exists('data-bs-dismiss', $closeButtonAttributes) === false) {
+            $closeButtonAttributes['data-bs-dismiss'] = 'alert';
+        }
+
+        if (array_key_exists('aria-label', $closeButtonAttributes) === false) {
+            $closeButtonAttributes['aria-label'] = 'Close';
+        }
 
         Html::addCssClass($closeButtonAttributes, 'btn-close');
 

--- a/src/Alert.php
+++ b/src/Alert.php
@@ -417,7 +417,7 @@ final class Alert extends \Yiisoft\Widget\Widget
         Html::addCssClass($headerAttributes, 'alert-heading');
 
         if ($this->headerTag === '') {
-            throw new InvalidArgumentException('Tag cannot be empty string.');
+            throw new InvalidArgumentException('Header tag cannot be empty string.');
         }
 
         return Html::tag($this->headerTag, '', $headerAttributes)->content($this->header)->encode(false)->render();
@@ -426,13 +426,15 @@ final class Alert extends \Yiisoft\Widget\Widget
     /**
      * Render toggle component.
      *
+     * @throws InvalidArgumentException if the close button tag is an empty string.
+     *
      * @return string The rendered toggle component.
      */
     private function renderToggle(): string
     {
         $buttonTag = match ($this->closeButtonTag) {
             null => Button::button(''),
-            '' => throw new InvalidArgumentException('Button tag cannot be empty string.'),
+            '' => throw new InvalidArgumentException('Close button tag cannot be empty string.'),
             default => Html::tag($this->closeButtonTag),
         };
 

--- a/src/Alert.php
+++ b/src/Alert.php
@@ -29,6 +29,7 @@ use function strtr;
  */
 final class Alert extends \Yiisoft\Widget\Widget
 {
+    private const CLASS_CLOSE_BUTTON = 'btn-close';
     private const NAME = 'alert';
     private array $attributes = [];
     private AlertVariant $alertType = AlertVariant::SECONDARY;
@@ -440,6 +441,10 @@ final class Alert extends \Yiisoft\Widget\Widget
 
         $closeButtonAttributes = $this->closeButtonAttributes;
 
+        $classesButton = $closeButtonAttributes['class'] ?? null;
+
+        unset($closeButtonAttributes['class']);
+
         if (array_key_exists('data-bs-dismiss', $closeButtonAttributes) === false) {
             $closeButtonAttributes['data-bs-dismiss'] = 'alert';
         }
@@ -448,7 +453,7 @@ final class Alert extends \Yiisoft\Widget\Widget
             $closeButtonAttributes['aria-label'] = 'Close';
         }
 
-        Html::addCssClass($closeButtonAttributes, 'btn-close');
+        Html::addCssClass($closeButtonAttributes, [self::CLASS_CLOSE_BUTTON, $classesButton]);
 
         return $buttonTag->addAttributes($closeButtonAttributes)->addContent($this->closeButtonLabel)->render();
     }

--- a/src/Alert.php
+++ b/src/Alert.php
@@ -186,7 +186,7 @@ final class Alert extends \Yiisoft\Widget\Widget
     }
 
     /**
-     * Sets the label for the close button.
+     * Sets the label for the close button in the alert component.
      *
      * @param string $value The label for the close button.
      *
@@ -201,7 +201,7 @@ final class Alert extends \Yiisoft\Widget\Widget
     }
 
     /**
-     * Sets the HTML tag to be used for the close button.
+     * Sets the HTML tag to be used for the close button in the alert component.
      *
      * @param string $value The HTML tag name for the close button.
      *

--- a/src/Alert.php
+++ b/src/Alert.php
@@ -10,9 +10,9 @@ use Yiisoft\Html\Html;
 use Yiisoft\Html\Tag\Button;
 use Yiisoft\Html\Tag\Div;
 
+use function array_filter;
 use function array_key_exists;
 use function array_merge;
-use function array_filter;
 use function preg_replace;
 use function strtr;
 

--- a/tests/AlertTest.php
+++ b/tests/AlertTest.php
@@ -209,6 +209,24 @@ final class AlertTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    public function testDimissableWithCloseButtonWithAriaLabelNullAttributes(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div class="alert alert-secondary alert-dismissible" role="alert">
+            Body
+            <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+            </div>
+            HTML,
+            Alert::widget()
+                ->body('Body')
+                ->closeButtonAttributes(['aria-label' => null])
+                ->dismissable(true)
+                ->id(false)
+                ->render(),
+        );
+    }
+
     public function testDimissableWithCloseButtonWithDataBsDismissAttributes(): void
     {
         Assert::equalsWithoutLE(
@@ -221,6 +239,24 @@ final class AlertTest extends \PHPUnit\Framework\TestCase
             Alert::widget()
                 ->body('Body')
                 ->closeButtonAttributes(['data-bs-dismiss' => 'my-component'])
+                ->dismissable(true)
+                ->id(false)
+                ->render(),
+        );
+    }
+
+    public function testDimissableWithCloseButtonWithDataBsDismissNullAttributes(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div class="alert alert-secondary alert-dismissible" role="alert">
+            Body
+            <button type="button" class="btn-close" aria-label="Close"></button>
+            </div>
+            HTML,
+            Alert::widget()
+                ->body('Body')
+                ->closeButtonAttributes(['data-bs-dismiss' => null])
                 ->dismissable(true)
                 ->id(false)
                 ->render(),

--- a/tests/AlertTest.php
+++ b/tests/AlertTest.php
@@ -179,7 +179,7 @@ final class AlertTest extends \PHPUnit\Framework\TestCase
             <<<HTML
             <div id="test" class="alert alert-secondary alert-dismissible" role="alert">
             Body
-            <button type="button" class="btn-lg btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            <button type="button" class="btn-close btn-lg" data-bs-dismiss="alert" aria-label="Close"></button>
             </div>
             HTML,
             Alert::widget()

--- a/tests/AlertTest.php
+++ b/tests/AlertTest.php
@@ -258,6 +258,14 @@ final class AlertTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    public function testDimissableWithCloseButtonWithTagNameEmpty(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Button tag cannot be empty string.');
+
+        Alert::widget()->closeButtonTag('')->dismissable(true)->render();
+    }
+
     public function testHeader(): void
     {
         Assert::equalsWithoutLE(

--- a/tests/AlertTest.php
+++ b/tests/AlertTest.php
@@ -191,6 +191,73 @@ final class AlertTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    public function testDimissableWithCloseButtonWithAriaLabelAttributes(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div class="alert alert-secondary alert-dismissible" role="alert">
+            Body
+            <button type="button" class="btn-close" aria-label="Close alert" data-bs-dismiss="alert"></button>
+            </div>
+            HTML,
+            Alert::widget()
+                ->body('Body')
+                ->closeButtonAttributes(['aria-label' => 'Close alert'])
+                ->dismissable(true)
+                ->id(false)
+                ->render(),
+        );
+    }
+
+    public function testDimissableWithCloseButtonWithDataBsDismissAttributes(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div class="alert alert-secondary alert-dismissible" role="alert">
+            Body
+            <button type="button" class="btn-close" data-bs-dismiss="my-component" aria-label="Close"></button>
+            </div>
+            HTML,
+            Alert::widget()
+                ->body('Body')
+                ->closeButtonAttributes(['data-bs-dismiss' => 'my-component'])
+                ->dismissable(true)
+                ->id(false)
+                ->render(),
+        );
+    }
+
+    public function testDimissableWithCloseButtonWithLabel(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div class="alert alert-secondary alert-dismissible" role="alert">
+            Body
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close">Close</button>
+            </div>
+            HTML,
+            Alert::widget()
+                ->body('Body')
+                ->closeButtonLabel('Close')
+                ->dismissable(true)
+                ->id(false)
+                ->render(),
+        );
+    }
+
+    public function testDimissableWithCloseButtonWithTagName(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div class="alert alert-secondary alert-dismissible" role="alert">
+            Body
+            <my-custom-tag class="btn-close" data-bs-dismiss="alert" aria-label="Close"></my-custom-tag>
+            </div>
+            HTML,
+            Alert::widget()->body('Body')->closeButtonTag('my-custom-tag')->dismissable(true)->id(false)->render(),
+        );
+    }
+
     public function testHeader(): void
     {
         Assert::equalsWithoutLE(
@@ -314,6 +381,8 @@ final class AlertTest extends \PHPUnit\Framework\TestCase
         $this->assertNotSame($alert, $alert->body('', true));
         $this->assertNotSame($alert, $alert->class(''));
         $this->assertNotSame($alert, $alert->closeButtonAttributes([]));
+        $this->assertNotSame($alert, $alert->closeButtonLabel(''));
+        $this->assertNotSame($alert, $alert->closeButtonTag(''));
         $this->assertNotSame($alert, $alert->dismissable(false));
         $this->assertNotSame($alert, $alert->fade(false));
         $this->assertNotSame($alert, $alert->id(false));

--- a/tests/AlertTest.php
+++ b/tests/AlertTest.php
@@ -297,7 +297,7 @@ final class AlertTest extends \PHPUnit\Framework\TestCase
     public function testDimissableWithCloseButtonWithTagNameEmpty(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Button tag cannot be empty string.');
+        $this->expectExceptionMessage('Close button tag cannot be empty string.');
 
         Alert::widget()->closeButtonTag('')->dismissable(true)->render();
     }
@@ -324,7 +324,7 @@ final class AlertTest extends \PHPUnit\Framework\TestCase
     public function testHeaderTagException(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Tag cannot be empty string.');
+        $this->expectExceptionMessage('Header tag cannot be empty string.');
 
         Alert::widget()->header('Header')->headerTag('')->render();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
