### PR TITLE
Enhance `Accordion` widget to accept `BackedEnum` for CSS classes.

### DIFF
--- a/src/Accordion.php
+++ b/src/Accordion.php
@@ -42,7 +42,7 @@ final class Accordion extends \Yiisoft\Widget\Widget
     private array $attributes = [];
     private array $bodyAttributes = [];
     private array $collapseAttributes = [];
-    private array $cssClass = [];
+    private array $cssClasses = [];
     private array $headerAttributes = [];
     private string $headerTag = 'h2';
     private bool|string $id = true;
@@ -85,7 +85,7 @@ final class Accordion extends \Yiisoft\Widget\Widget
     public function addClass(BackedEnum|string|null ...$values): self
     {
         $new = clone $this;
-        $new->cssClass = array_merge($new->cssClass, $values);
+        $new->cssClasses = array_merge($new->cssClasses, $values);
 
         return $new;
     }
@@ -167,19 +167,19 @@ final class Accordion extends \Yiisoft\Widget\Widget
      * Multiple classes can be added by passing them as separate arguments. `null` values are filtered out
      * automatically.
      *
-     * @param BackedEnum|string|null ...$value One or more CSS class names to set. Pass `null` to skip setting a class.
+     * @param BackedEnum|string|null ...$values One or more CSS class names to set. Pass `null` to skip setting a class.
      * For example:
      *
      * ```php
-     * $accordion->class('custom-class', null, 'another-class');
+     * $accordion->class('custom-class', null, 'another-class', BackGroundColor::PRIMARY());
      * ```
      *
      * @return self A new instance with the specified CSS classes set.
      */
-    public function class(BackedEnum|string|null ...$value): self
+    public function class(BackedEnum|string|null ...$values): self
     {
         $new = clone $this;
-        $new->cssClass = $value;
+        $new->cssClasses = $values;
 
         return $new;
     }
@@ -213,7 +213,7 @@ final class Accordion extends \Yiisoft\Widget\Widget
     public function flush(bool $value = true): self
     {
         $new = clone $this;
-        $new->cssClass['flush'] = $value ? 'accordion-flush' : null;
+        $new->cssClasses['flush'] = $value ? 'accordion-flush' : null;
 
         return $new;
     }
@@ -334,7 +334,7 @@ final class Accordion extends \Yiisoft\Widget\Widget
             default => $this->id,
         };
 
-        Html::addCssClass($attributes, [self::NAME, $classes, ...$this->cssClass]);
+        Html::addCssClass($attributes, [self::NAME, $classes, ...$this->cssClasses]);
 
         return Div::tag()
             ->addAttributes($attributes)

--- a/src/Accordion.php
+++ b/src/Accordion.php
@@ -75,7 +75,7 @@ final class Accordion extends \Yiisoft\Widget\Widget
      * For example:
      *
      * ```php
-     * $accordion->addClass('custom-class', null, 'another-class', BackGroundColor::PRIMARY());
+     * $accordion->addClass('custom-class', null, 'another-class', BackGroundColor::PRIMARY);
      * ```
      *
      * @return self A new instance with the specified CSS classes added to existing ones.
@@ -171,7 +171,7 @@ final class Accordion extends \Yiisoft\Widget\Widget
      * For example:
      *
      * ```php
-     * $accordion->class('custom-class', null, 'another-class', BackGroundColor::PRIMARY());
+     * $accordion->class('custom-class', null, 'another-class', BackGroundColor::PRIMARY);
      * ```
      *
      * @return self A new instance with the specified CSS classes set.

--- a/src/Accordion.php
+++ b/src/Accordion.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Yii\Bootstrap5;
 
+use BackedEnum;
 use InvalidArgumentException;
 use Yiisoft\Html\Html;
 use Yiisoft\Html\Tag\Button;
@@ -71,24 +72,21 @@ final class Accordion extends \Yiisoft\Widget\Widget
      * Multiple classes can be added by passing them as separate arguments. `null` values are filtered out
      * automatically.
      *
-     * @param string|null ...$value One or more CSS class names to add. Pass `null` to skip adding a class.
+     * @param BackedEnum|string|null ...$values One or more CSS class names to add. Pass `null` to skip adding a class.
      * For example:
      *
      * ```php
-     * $accordion->addClass('custom-class', null, 'another-class');
+     * $accordion->addClass('custom-class', null, 'another-class', BackGroundColor::PRIMARY());
      * ```
      *
      * @return self A new instance with the specified CSS classes added to existing ones.
      *
      * @link https://html.spec.whatwg.org/#classes
      */
-    public function addClass(string|null ...$value): self
+    public function addClass(BackedEnum|string|null ...$values): self
     {
         $new = clone $this;
-        $new->cssClass = array_merge(
-            $new->cssClass,
-            array_filter($value, static fn ($v) => $v !== null)
-        );
+        $new->cssClass = array_merge($new->cssClass, $values);
 
         return $new;
     }
@@ -170,7 +168,7 @@ final class Accordion extends \Yiisoft\Widget\Widget
      * Multiple classes can be added by passing them as separate arguments. `null` values are filtered out
      * automatically.
      *
-     * @param string|null ...$value One or more CSS class names to set. Pass `null` to skip setting a class.
+     * @param BackedEnum|string|null ...$value One or more CSS class names to set. Pass `null` to skip setting a class.
      * For example:
      *
      * ```php
@@ -179,10 +177,10 @@ final class Accordion extends \Yiisoft\Widget\Widget
      *
      * @return self A new instance with the specified CSS classes set.
      */
-    public function class(string|null ...$value): self
+    public function class(BackedEnum|string|null ...$value): self
     {
         $new = clone $this;
-        $new->cssClass = array_filter($value, static fn ($v) => $v !== null);
+        $new->cssClass = $value;
 
         return $new;
     }

--- a/src/Accordion.php
+++ b/src/Accordion.php
@@ -10,7 +10,6 @@ use Yiisoft\Html\Html;
 use Yiisoft\Html\Tag\Button;
 use Yiisoft\Html\Tag\Div;
 
-use function array_filter;
 use function array_key_exists;
 use function array_merge;
 use function implode;

--- a/tests/AccordionTest.php
+++ b/tests/AccordionTest.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use Yiisoft\Yii\Bootstrap5\Accordion;
 use Yiisoft\Yii\Bootstrap5\AccordionItem;
 use Yiisoft\Yii\Bootstrap5\Tests\Support\Assert;
+use Yiisoft\Yii\Bootstrap5\Utility\BackgroundColor;
 
 /**
  * Tests for `Accordion` widget
@@ -48,7 +49,7 @@ final class AccordionTest extends \PHPUnit\Framework\TestCase
     public function testAddClass(): void
     {
         $accordion = Accordion::widget()
-            ->addClass('test-class', null)
+            ->addClass('test-class', null, BackgroundColor::PRIMARY)
             ->id('accordion')
             ->items(
                 new AccordionItem('Accordion Item #1', 'This is the first item\'s accordion body.', 'accordion-1'),
@@ -56,7 +57,7 @@ final class AccordionTest extends \PHPUnit\Framework\TestCase
 
         Assert::equalsWithoutLE(
             <<<HTML
-            <div id="accordion" class="accordion test-class">
+            <div id="accordion" class="accordion test-class bg-primary">
             <div class="accordion-item">
             <h2 class="accordion-header">
             <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" data-bs-target="#accordion-1" aria-expanded="false" aria-controls="accordion-1">
@@ -76,7 +77,7 @@ final class AccordionTest extends \PHPUnit\Framework\TestCase
 
         Assert::equalsWithoutLE(
             <<<HTML
-            <div id="accordion" class="accordion test-class test-class-1 test-class-2">
+            <div id="accordion" class="accordion test-class bg-primary test-class-1 test-class-2">
             <div class="accordion-item">
             <h2 class="accordion-header">
             <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" data-bs-target="#accordion-1" aria-expanded="false" aria-controls="accordion-1">
@@ -339,7 +340,7 @@ final class AccordionTest extends \PHPUnit\Framework\TestCase
     {
         Assert::equalsWithoutLE(
             <<<HTML
-            <div id="accordion" class="accordion custom-class another-class">
+            <div id="accordion" class="accordion custom-class another-class bg-primary">
             <div class="accordion-item">
             <h2 class="accordion-header">
             <button type="button" class="accordion-button collapsed" data-bs-toggle="collapse" data-bs-target="#accordion-1" aria-expanded="false" aria-controls="accordion-1">
@@ -356,7 +357,7 @@ final class AccordionTest extends \PHPUnit\Framework\TestCase
             HTML,
             Accordion::widget()
                 ->addClass('test-class')
-                ->class('custom-class', 'another-class')
+                ->class('custom-class', 'another-class', BackgroundColor::PRIMARY)
                 ->id('accordion')
                 ->items(
                     new AccordionItem('Accordion Item #1', 'This is the first item\'s accordion body.', 'accordion-1'),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
