### PR TITLE
Enhance `Alert` widget to accept `BackedEnum` for CSS classes.

### DIFF
--- a/src/Alert.php
+++ b/src/Alert.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Yiisoft\Yii\Bootstrap5;
 
+use BackedEnum;
 use InvalidArgumentException;
 use Stringable;
 use Yiisoft\Html\Html;
 use Yiisoft\Html\Tag\Button;
 use Yiisoft\Html\Tag\Div;
 
-use function array_filter;
 use function array_key_exists;
 use function array_merge;
 use function preg_replace;
@@ -34,7 +34,7 @@ final class Alert extends \Yiisoft\Widget\Widget
     private array $attributes = [];
     private AlertVariant $alertType = AlertVariant::SECONDARY;
     private string|Stringable $body = '';
-    private array $cssClass = [];
+    private array $cssClasses = [];
     private array $closeButtonAttributes = [];
     private string|null $closeButtonTag = null;
     private string $closeButtonLabel = '';
@@ -67,24 +67,21 @@ final class Alert extends \Yiisoft\Widget\Widget
      * Multiple classes can be added by passing them as separate arguments. `null` values are filtered out
      * automatically.
      *
-     * @param string|null ...$value One or more CSS class names to add. Pass `null` to skip adding a class.
+     * @param BackedEnum|string|null ...$values One or more CSS class names to add. Pass `null` to skip adding a class.
      * For example:
      *
      * ```php
-     * $alert->addClass('custom-class', null, 'another-class');
+     * $alert->addClass('custom-class', null, 'another-class', BackgroundColor::PRIMARY());
      * ```
      *
      * @return self A new instance with the specified CSS classes added to existing ones.
      *
      * @link https://html.spec.whatwg.org/#classes
      */
-    public function addClass(string|null ...$value): self
+    public function addClass(BackedEnum|string|null ...$values): self
     {
         $new = clone $this;
-        $new->cssClass = array_merge(
-            $new->cssClass,
-            array_filter($value, static fn ($v) => $v !== null)
-        );
+        $new->cssClasses = array_merge($new->cssClasses, $values);
 
         return $new;
     }
@@ -153,19 +150,19 @@ final class Alert extends \Yiisoft\Widget\Widget
      * Multiple classes can be added by passing them as separate arguments. `null` values are filtered out
      * automatically.
      *
-     * @param string|null ...$value One or more CSS class names to set. Pass `null` to skip setting a class.
+     * @param BackedEnum|string|null ...$values One or more CSS class names to set. Pass `null` to skip setting a class.
      * For example:
      *
      * ```php
-     * $alert->class('custom-class', null, 'another-class');
+     * $alert->class('custom-class', null, 'another-class', BackgroundColor::PRIMARY());
      * ```
      *
      * @return self A new instance with the specified CSS classes set.
      */
-    public function class(string|null ...$value): self
+    public function class(BackedEnum|string|null ...$values): self
     {
         $new = clone $this;
-        $new->cssClass = array_filter($value, static fn ($v) => $v !== null);
+        $new->cssClasses = $values;
 
         return $new;
     }
@@ -331,15 +328,7 @@ final class Alert extends \Yiisoft\Widget\Widget
     }
 
     /**
-     * Set the alert variant. The following options are allowed:
-     * - `AlertVariant::PRIMARY`: Primary alert.
-     * - `AlertVariant::SECONDARY`: Secondary alert.
-     * - `AlertVariant::SUCCESS`: Success alert.
-     * - `AlertVariant::DANGER`: Danger alert.
-     * - `AlertVariant::WARNING`: Warning alert.
-     * - `AlertVariant::INFO`: Info alert.
-     * - `AlertVariant::LIGHT`: Light alert.
-     * - `AlertVariant::DARK`: Dark alert.
+     * Set the alert variant.
      *
      * @param AlertVariant $value The alert variant.
      *
@@ -375,7 +364,7 @@ final class Alert extends \Yiisoft\Widget\Widget
 
         unset($attributes['class'], $attributes['id']);
 
-        Html::addCssClass($attributes, [self::NAME, $this->alertType->value, $classes, ...$this->cssClass]);
+        Html::addCssClass($attributes, [self::NAME, $this->alertType->value, $classes, ...$this->cssClasses]);
 
         if ($this->dismissable) {
             Html::addCssClass($attributes, 'alert-dismissible');

--- a/src/Alert.php
+++ b/src/Alert.php
@@ -71,7 +71,7 @@ final class Alert extends \Yiisoft\Widget\Widget
      * For example:
      *
      * ```php
-     * $alert->addClass('custom-class', null, 'another-class', BackgroundColor::PRIMARY());
+     * $alert->addClass('custom-class', null, 'another-class', BackgroundColor::PRIMARY);
      * ```
      *
      * @return self A new instance with the specified CSS classes added to existing ones.
@@ -154,7 +154,7 @@ final class Alert extends \Yiisoft\Widget\Widget
      * For example:
      *
      * ```php
-     * $alert->class('custom-class', null, 'another-class', BackgroundColor::PRIMARY());
+     * $alert->class('custom-class', null, 'another-class', BackgroundColor::PRIMARY);
      * ```
      *
      * @return self A new instance with the specified CSS classes set.

--- a/src/AlertVariant.php
+++ b/src/AlertVariant.php
@@ -11,12 +11,36 @@ namespace Yiisoft\Yii\Bootstrap5;
  */
 enum AlertVariant: string
 {
+    /**
+     * Primary variant.
+     */
     case PRIMARY = 'alert-primary';
+    /**
+     * Secondary variant.
+     */
     case SECONDARY = 'alert-secondary';
+    /**
+     * Success variant.
+     */
     case SUCCESS = 'alert-success';
+    /**
+     * Danger variant.
+     */
     case DANGER = 'alert-danger';
+    /**
+     * Warning variant.
+     */
     case WARNING = 'alert-warning';
+    /**
+     * Info variant.
+     */
     case INFO = 'alert-info';
+    /**
+     * Light variant.
+     */
     case LIGHT = 'alert-light';
+    /**
+     * Dark variant.
+     */
     case DARK = 'alert-dark';
 }

--- a/tests/AlertTest.php
+++ b/tests/AlertTest.php
@@ -7,6 +7,7 @@ namespace Yiisoft\Yii\Bootstrap5\Tests;
 use Yiisoft\Yii\Bootstrap5\Alert;
 use Yiisoft\Yii\Bootstrap5\AlertVariant;
 use Yiisoft\Yii\Bootstrap5\Tests\Support\Assert;
+use Yiisoft\Yii\Bootstrap5\Utility\BackgroundColor;
 
 /**
  * Tests for `Alert` widget.
@@ -44,11 +45,11 @@ final class AlertTest extends \PHPUnit\Framework\TestCase
 
     public function testAddCssClass(): void
     {
-        $alert = Alert::widget()->addClass('test-class', null)->body('Body')->id(false);
+        $alert = Alert::widget()->addClass('test-class', null, BackgroundColor::PRIMARY)->body('Body')->id(false);
 
         Assert::equalsWithoutLE(
             <<<HTML
-            <div class="alert alert-secondary test-class" role="alert">
+            <div class="alert alert-secondary test-class bg-primary" role="alert">
             Body
             </div>
             HTML,
@@ -57,7 +58,7 @@ final class AlertTest extends \PHPUnit\Framework\TestCase
 
         Assert::equalsWithoutLE(
             <<<HTML
-            <div class="alert alert-secondary test-class test-class-1 test-class-2" role="alert">
+            <div class="alert alert-secondary test-class bg-primary test-class-1 test-class-2" role="alert">
             Body
             </div>
             HTML,
@@ -139,13 +140,13 @@ final class AlertTest extends \PHPUnit\Framework\TestCase
     {
         Assert::equalsWithoutLE(
             <<<HTML
-            <div class="alert alert-secondary custom-class another-class" role="alert">
+            <div class="alert alert-secondary custom-class another-class bg-primary" role="alert">
             Body
             </div>
             HTML,
             Alert::widget()
                 ->addClass('test-class')
-                ->class('custom-class', 'another-class')
+                ->class('custom-class', 'another-class', BackgroundColor::PRIMARY)
                 ->body('Body')
                 ->id(false)
                 ->render(),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
