### PR TITLE
Enhance `Breadcrumbs` widget to accept `BackedEnum` for CSS classes.

### DIFF
--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -72,7 +72,7 @@ final class Breadcrumbs extends \Yiisoft\Widget\Widget
      * For example:
      *
      * ```php
-     * $breadcrumb->addClass('custom-class', null, 'another-class', BackgroundColor::PRIMARY());
+     * $breadcrumb->addClass('custom-class', null, 'another-class', BackgroundColor::PRIMARY);
      * ```
      *
      * @return self A new instance with the specified CSS classes added to existing ones.

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Yii\Bootstrap5;
 
+use BackedEnum;
 use InvalidArgumentException;
 use RuntimeException;
 use Yiisoft\Html\Html;
@@ -11,7 +12,6 @@ use Yiisoft\Html\Tag\A;
 use Yiisoft\Html\Tag\Li;
 use Yiisoft\Html\Tag\Nav;
 
-use function array_filter;
 use function array_merge;
 use function implode;
 
@@ -38,7 +38,7 @@ final class Breadcrumbs extends \Yiisoft\Widget\Widget
     private const LIST_NAME = 'breadcrumb';
     private const ITEM_NAME = 'breadcrumb-item';
     private array $attributes = [];
-    private array $cssClass = [];
+    private array $cssClasses = [];
     private string $itemActiveClass = 'active';
     private array $itemAttributes = [];
     private array $linkAttributes = [];
@@ -68,24 +68,21 @@ final class Breadcrumbs extends \Yiisoft\Widget\Widget
      * Multiple classes can be added by passing them as separate arguments. `null` values are filtered out
      * automatically.
      *
-     * @param string|null ...$value One or more CSS class names to add. Pass `null` to skip adding a class.
+     * @param BackedEnum|string|null ...$values One or more CSS class names to add. Pass `null` to skip adding a class.
      * For example:
      *
      * ```php
-     * $breadcrumb->addClass('custom-class', null, 'another-class');
+     * $breadcrumb->addClass('custom-class', null, 'another-class', BackgroundColor::PRIMARY());
      * ```
      *
      * @return self A new instance with the specified CSS classes added to existing ones.
      *
      * @link https://html.spec.whatwg.org/#classes
      */
-    public function addClass(string|null ...$value): self
+    public function addClass(BackedEnum|string|null ...$values): self
     {
         $new = clone $this;
-        $new->cssClass = array_merge(
-            $new->cssClass,
-            array_filter($value, static fn ($v) => $v !== null)
-        );
+        $new->cssClasses = array_merge($new->cssClasses, $values);
 
         return $new;
     }
@@ -130,7 +127,7 @@ final class Breadcrumbs extends \Yiisoft\Widget\Widget
      * Multiple classes can be added by passing them as separate arguments. `null` values are filtered out
      * automatically.
      *
-     * @param string|null ...$value One or more CSS class names to set. Pass `null` to skip setting a class.
+     * @param BackedEnum|string|null ...$values One or more CSS class names to set. Pass `null` to skip setting a class.
      * For example:
      *
      * ```php
@@ -139,10 +136,10 @@ final class Breadcrumbs extends \Yiisoft\Widget\Widget
      *
      * @return self A new instance with the specified CSS classes set.
      */
-    public function class(string|null ...$value): self
+    public function class(BackedEnum|string|null ...$values): self
     {
         $new = clone $this;
-        $new->cssClass = array_filter($value, static fn ($v) => $v !== null);
+        $new->cssClasses = $values;
 
         return $new;
     }
@@ -279,6 +276,11 @@ final class Breadcrumbs extends \Yiisoft\Widget\Widget
         return $new;
     }
 
+    /**
+     * Run the breadcrumb widget.
+     *
+     * @return string The HTML representation of the element.
+     */
     public function render(): string
     {
         $attributes = $this->attributes;
@@ -296,12 +298,17 @@ final class Breadcrumbs extends \Yiisoft\Widget\Widget
 
         return Nav::tag()
             ->addAttributes($attributes)
-            ->addClass(...$this->cssClass)
+            ->addClass(...$this->cssClasses)
             ->content("\n", $list, "\n")
             ->encode(false)
             ->render();
     }
 
+    /**
+     * Renders the list of items in the breadcrumbs.
+     *
+     * @return string The rendering result.
+     */
     private function renderList(): string
     {
         $listAttributes = $this->listAttributes;

--- a/tests/BreadcrumbsTest.php
+++ b/tests/BreadcrumbsTest.php
@@ -9,6 +9,7 @@ use RuntimeException;
 use Yiisoft\Yii\Bootstrap5\Link;
 use Yiisoft\Yii\Bootstrap5\Breadcrumbs;
 use Yiisoft\Yii\Bootstrap5\Tests\Support\Assert;
+use Yiisoft\Yii\Bootstrap5\Utility\BackgroundColor;
 
 /**
  * Tests for `Breadcrumbs` widget
@@ -61,7 +62,7 @@ final class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
     {
         $alert = Breadcrumbs::widget()
             ->ariaLabel('Basic example of breadcrumbs')
-            ->addClass('test-class', null)
+            ->addClass('test-class', null, BackgroundColor::PRIMARY)
             ->links(
                 new Link('Home', '/'),
                 new Link('Library', '#', active: true),
@@ -71,7 +72,7 @@ final class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
 
         Assert::equalsWithoutLE(
             <<<HTML
-            <nav class="test-class" aria-label="Basic example of breadcrumbs">
+            <nav class="test-class bg-primary" aria-label="Basic example of breadcrumbs">
             <ol class="breadcrumb">
             <li class="breadcrumb-item"><a href="/">Home</a></li>
             <li class="breadcrumb-item active" aria-current="page"><a href="#">Library</a></li>
@@ -84,7 +85,7 @@ final class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
 
         Assert::equalsWithoutLE(
             <<<HTML
-            <nav class="test-class test-class-1 test-class-2" aria-label="Basic example of breadcrumbs">
+            <nav class="test-class bg-primary test-class-1 test-class-2" aria-label="Basic example of breadcrumbs">
             <ol class="breadcrumb">
             <li class="breadcrumb-item"><a href="/">Home</a></li>
             <li class="breadcrumb-item active" aria-current="page"><a href="#">Library</a></li>
@@ -173,7 +174,7 @@ final class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
     {
         Assert::equalsWithoutLE(
             <<<HTML
-            <nav class="custom-class another-class" aria-label="breadcrumb">
+            <nav class="custom-class another-class bg-primary" aria-label="breadcrumb">
             <ol class="breadcrumb">
             <li class="breadcrumb-item"><a href="/">Home</a></li>
             <li class="breadcrumb-item"><a href="#">Library</a></li>
@@ -183,7 +184,7 @@ final class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
             HTML,
             Breadcrumbs::widget()
                 ->addClass('test-class')
-                ->class('custom-class', 'another-class')
+                ->class('custom-class', 'another-class', BackgroundColor::PRIMARY)
                 ->links(
                     new Link('Home', '/'),
                     new Link('Library', '#'),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
