### PR TITLE
Rename `Link` class to `BreadcrumbLink` and update related references, introduce static `to()` method for instantiation.

### DIFF
--- a/src/BreadcrumbLink.php
+++ b/src/BreadcrumbLink.php
@@ -33,6 +33,13 @@ final class BreadcrumbLink
     private array $attributes = [];
 
     /**
+     * Use {@see BreadcrumbLink::to()} to create an instance.
+     */
+    private function __construct()
+    {
+    }
+
+    /**
      * Creates a new {@see BreadcrumbLink} instance.
      *
      * @param string $label The label text to display.

--- a/src/BreadcrumbLink.php
+++ b/src/BreadcrumbLink.php
@@ -7,7 +7,22 @@ namespace Yiisoft\Yii\Bootstrap5;
 use Yiisoft\Html\Html;
 
 /**
- * Represents a link.
+ * BreadcrumbLink represents a single breadcrumb navigation link.
+ *
+ * Each link can be either active or inactive, and can be rendered as a plain text (when active) or as a hyperlink
+ * (when inactive).
+ *
+ * Example:
+ * ```php
+ * // Create a standard link
+ * BreadcrumbLink::to('Home', '/');
+ *
+ * // Create an active link (current page)
+ * BreadcrumbLink::to('Current Page', null, true);
+ *
+ * // Create a link with custom attributes
+ * BreadcrumbLink::to('Link', '/path', false, ['class' => 'custom-link']);
+ * ```
  */
 final class BreadcrumbLink
 {
@@ -17,6 +32,17 @@ final class BreadcrumbLink
     private bool $encodeLabel = true;
     private array $attributes = [];
 
+    /**
+     * Creates a new {@see BreadcrumbLink} instance.
+     *
+     * @param string $label The label text to display.
+     * @param string|null $url The URL for the link.
+     * @param bool $active Whether this link represents the current page.
+     * @param array $attributes Additional HTML attributes for the link.
+     * @param bool $encodeLabel Whether to HTML encode the label.
+     *
+     * @return self A new instance with the specified configuration.
+     */
     public static function to(
         string $label,
         string $url = null,
@@ -25,19 +51,17 @@ final class BreadcrumbLink
         bool $encodeLabel = true
     ): self {
         $new = new self();
-        $new->label = $label;
-        $new->url = $url;
         $new->active = $active;
         $new->attributes = $attributes;
         $new->encodeLabel = $encodeLabel;
+        $new->label = $label;
+        $new->url = $url;
 
         return $new;
     }
 
     /**
-     * Returns the HTML attributes for the link.
-     *
-     * @return array The attributes.
+     * @return array Returns the HTML attributes for the link.
      */
     public function getAttributes(): array
     {
@@ -45,9 +69,8 @@ final class BreadcrumbLink
     }
 
     /**
-     * Returns the encoded label content.
-     *
-     * @return string The encoded label content.
+     * @return string Returns the encoded label content. For default behavior, the label will be HTML-encoded. You can
+     * disable this by setting `encodeLabel` to `false`.
      */
     public function getLabel(): string
     {
@@ -55,9 +78,7 @@ final class BreadcrumbLink
     }
 
     /**
-     * Returns the URL for the link.
-     *
-     * @return string|null The URL.
+     * @return string|null  Returns the URL for the breadcrumb link.
      */
     public function getUrl(): string|null
     {

--- a/src/BreadcrumbLink.php
+++ b/src/BreadcrumbLink.php
@@ -9,15 +9,29 @@ use Yiisoft\Html\Html;
 /**
  * Represents a link.
  */
-final class Link
+final class BreadcrumbLink
 {
-    public function __construct(
-        private readonly string $label = '',
-        private readonly string|null $url = null,
-        private readonly bool $active = false,
-        private readonly bool $encodeLabel = true,
-        private readonly array $attributes = [],
-    ) {
+    private string $label = '';
+    private string|null $url = null;
+    private bool $active = false;
+    private bool $encodeLabel = true;
+    private array $attributes = [];
+
+    public static function to(
+        string $label,
+        string $url = null,
+        bool $active = false,
+        array $attributes = [],
+        bool $encodeLabel = true
+    ): self {
+        $new = new self();
+        $new->label = $label;
+        $new->url = $url;
+        $new->active = $active;
+        $new->attributes = $attributes;
+        $new->encodeLabel = $encodeLabel;
+
+        return $new;
     }
 
     /**

--- a/src/BreadcrumbLink.php
+++ b/src/BreadcrumbLink.php
@@ -68,7 +68,7 @@ final class BreadcrumbLink
     }
 
     /**
-     * @return array Returns the HTML attributes for the link.
+     * @return array The HTML attributes for the link.
      */
     public function getAttributes(): array
     {
@@ -76,7 +76,7 @@ final class BreadcrumbLink
     }
 
     /**
-     * @return string Returns the encoded label content. For default behavior, the label will be HTML-encoded. You can
+     * @return string The encoded label content. For default behavior, the label will be HTML-encoded. You can
      * disable this by setting `encodeLabel` to `false`.
      */
     public function getLabel(): string
@@ -85,7 +85,7 @@ final class BreadcrumbLink
     }
 
     /**
-     * @return string|null  Returns the URL for the breadcrumb link.
+     * @return string|null The URL for the breadcrumb link.
      */
     public function getUrl(): string|null
     {

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -219,7 +219,7 @@ final class Breadcrumbs extends \Yiisoft\Widget\Widget
      *
      * @return self A new instance with the specified links to appear in the breadcrumbs.
      *
-     * @psalm-param Link[] $value The links to appear in the breadcrumbs.
+     * @psalm-param BreadcrumbLink[] $value The links to appear in the breadcrumbs.
      */
     public function links(BreadcrumbLink ...$value): self
     {

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -12,7 +12,6 @@ use Yiisoft\Html\Tag\A;
 use Yiisoft\Html\Tag\Li;
 use Yiisoft\Html\Tag\Nav;
 
-use function array_merge;
 use function implode;
 
 /**
@@ -57,7 +56,7 @@ final class Breadcrumbs extends \Yiisoft\Widget\Widget
     public function addAttributes(array $values): self
     {
         $new = clone $this;
-        $new->attributes = array_merge($this->attributes, $values);
+        $new->attributes = [...$new->attributes, ...$values];
 
         return $new;
     }
@@ -82,7 +81,27 @@ final class Breadcrumbs extends \Yiisoft\Widget\Widget
     public function addClass(BackedEnum|string|null ...$values): self
     {
         $new = clone $this;
-        $new->cssClasses = array_merge($new->cssClasses, $values);
+        $new->cssClasses = [...$this->cssClasses, ...$values];
+
+        return $new;
+    }
+
+    /**
+     * Adds a CSS style for the breadcrumb component.
+     *
+     * @param array|string $value The CSS style for the breadcrumb component. If an array, the values will be separated
+     * by a space. If a string, it will be added as is. For example, 'color: red;'. If the value is an array, the values
+     * will be separated by a space. e.g., ['color' => 'red', 'font-weight' => 'bold'] will be rendered as
+     * 'color: red; font-weight: bold;'.
+     * @param bool $overwrite Whether to overwrite existing styles with the same name. If `false`, the new value will be
+     * appended to the existing one.
+     *
+     * @return self A new instance with the specified CSS style value added.
+     */
+    public function addCssStyle(array|string $value, bool $overwrite = true): self
+    {
+        $new = clone $this;
+        Html::addCssStyle($new->attributes, $value, $overwrite);
 
         return $new;
     }

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -23,9 +23,9 @@ use function implode;
  * ```php
  * echo Breadcrumbs::widget()
  *     ->links(
- *         new Link('Home', '#'),
- *         new Link('Library', '#'),
- *         new Link('Data', active: true),
+ *         BreadcrumbLink::to('Home', '#'),
+ *         BreadcrumbLink::to('Library', '#'),
+ *         BreadcrumbLink::to('Data', active: true),
  *     )
  *     ->listId(false)
  *     ->render();
@@ -215,13 +215,13 @@ final class Breadcrumbs extends \Yiisoft\Widget\Widget
     /**
      * List of links to appear in the breadcrumbs. If this property is empty, the widget will not render anything.
      *
-     * @param array $value The links to appear in the breadcrumbs.
+     * @param BreadcrumnLink ...$value The links to appear in the breadcrumbs.
      *
      * @return self A new instance with the specified links to appear in the breadcrumbs.
      *
      * @psalm-param Link[] $value The links to appear in the breadcrumbs.
      */
-    public function links(Link ...$value): self
+    public function links(BreadcrumbLink ...$value): self
     {
         $new = clone $this;
         $new->links = $value;
@@ -358,21 +358,21 @@ final class Breadcrumbs extends \Yiisoft\Widget\Widget
     /**
      * Renders a single breadcrumb item.
      *
-     * @param Link $link The breadcrumb item to render.
+     * @param BreadcrumbLink $breadcrumbLink The breadcrumb item to render.
      *
      * @return string The rendering result.
      */
-    private function renderItem(Link $link): string
+    private function renderItem(BreadcrumbLink $breadcrumbLink): string
     {
         $itemsAttributes = $this->itemAttributes;
         $classes = $itemsAttributes['class'] ?? null;
 
         unset($itemsAttributes['class']);
 
-        $linkTag = $this->renderLink($link);
+        $linkTag = $this->renderLink($breadcrumbLink);
         Html::addCssClass($itemsAttributes, [self::ITEM_NAME, $classes]);
 
-        if ($link->isActive()) {
+        if ($breadcrumbLink->isActive()) {
             $itemsAttributes['aria-current'] = 'page';
 
             Html::addCssClass($itemsAttributes, $this->itemActiveClass);
@@ -384,20 +384,20 @@ final class Breadcrumbs extends \Yiisoft\Widget\Widget
     /**
      * Renders a single breadcrumb link.
      *
-     * @param Link $link The breadcrumb link to render.
+     * @param BreadcrumbLink $breadcrumbLink The breadcrumb link to render.
      *
      * @return string The rendering result.
      */
-    private function renderLink(Link $link): string
+    private function renderLink(BreadcrumbLink $breadcrumbLink): string
     {
-        $label = $link->getLabel();
-        $url = $link->getUrl();
+        $label = $breadcrumbLink->getLabel();
+        $url = $breadcrumbLink->getUrl();
 
         return match ($url) {
             null => $label,
             default => A::tag()
                 ->attributes($this->linkAttributes)
-                ->addAttributes($link->getAttributes())
+                ->addAttributes($breadcrumbLink->getAttributes())
                 ->content($label)
                 ->url($url)
                 ->encode(false)

--- a/tests/BreadcrumbLinkTest.php
+++ b/tests/BreadcrumbLinkTest.php
@@ -12,7 +12,7 @@ use Yiisoft\Yii\Bootstrap5\Link;
  *
  * @group breadcrumblink
  */
-final class BreadcrumLinkTest extends \PHPUnit\Framework\TestCase
+final class BreadcrumbLinkTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetAttributes(): void
     {

--- a/tests/BreadcrumbLinkTest.php
+++ b/tests/BreadcrumbLinkTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Yii\Bootstrap5\Tests;
 
+use Yiisoft\Yii\Bootstrap5\BreadcrumbLink;
 use Yiisoft\Yii\Bootstrap5\Link;
 
 /**
@@ -11,39 +12,39 @@ use Yiisoft\Yii\Bootstrap5\Link;
  *
  * @group breadcrumblink
  */
-final class LinkTest extends \PHPUnit\Framework\TestCase
+final class BreadcrumLinkTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetAttributes(): void
     {
-        $link = new Link('label', 'url', attributes: ['class' => 'test']);
+        $link = BreadcrumbLink::to('label', 'url', attributes: ['class' => 'test']);
 
         $this->assertSame(['class' => 'test'], $link->getAttributes());
     }
 
     public function testGetLabel(): void
     {
-        $label = new Link('<strong>label</strong>', 'url');
+        $label = BreadcrumbLink::to('<strong>label</strong>', 'url');
 
         $this->assertSame('&lt;strong&gt;label&lt;/strong&gt;', $label->getLabel());
     }
 
     public function testGetLabelEncodeWithFalse(): void
     {
-        $label = new Link('<strong>label</strong>', 'url', encodeLabel: false);
+        $label = BreadcrumbLink::to('<strong>label</strong>', 'url', encodeLabel: false);
 
         $this->assertSame('<strong>label</strong>', $label->getLabel());
     }
 
     public function testGetUrl(): void
     {
-        $url = new Link('label', 'url');
+        $url = BreadcrumbLink::to('label', 'url');
 
         $this->assertSame('url', $url->getUrl());
     }
 
     public function testIsActive(): void
     {
-        $active = new Link('label', 'url', active: true);
+        $active = BreadcrumbLink::to('label', 'url', active: true);
 
         $this->assertTrue($active->isActive());
     }

--- a/tests/BreadcrumbsTest.php
+++ b/tests/BreadcrumbsTest.php
@@ -6,7 +6,7 @@ namespace Yiisoft\Yii\Bootstrap5\Tests;
 
 use InvalidArgumentException;
 use RuntimeException;
-use Yiisoft\Yii\Bootstrap5\Link;
+use Yiisoft\Yii\Bootstrap5\BreadcrumbLink;
 use Yiisoft\Yii\Bootstrap5\Breadcrumbs;
 use Yiisoft\Yii\Bootstrap5\Tests\Support\Assert;
 use Yiisoft\Yii\Bootstrap5\Utility\BackgroundColor;
@@ -33,9 +33,9 @@ final class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
             Breadcrumbs::widget()
                 ->ariaLabel('Basic example of breadcrumbs')
                 ->links(
-                    new Link('Home', '/'),
-                    new Link('Library', '#', active: true),
-                    new Link('Data', '#'),
+                    BreadcrumbLink::to('Home', '/'),
+                    BreadcrumbLink::to('Library', '#', active: true),
+                    BreadcrumbLink::to('Data', '#'),
                 )
                 ->listId(false)
                 ->render(),
@@ -50,9 +50,9 @@ final class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
         Breadcrumbs::widget()
             ->ariaLabel('Basic example of breadcrumbs')
             ->links(
-                new Link('Home', '/'),
-                new Link('Library', '#', active: true),
-                new Link('Data', '#', active: true),
+                BreadcrumbLink::to('Home', '/'),
+                BreadcrumbLink::to('Library', '#', active: true),
+                BreadcrumbLink::to('Data', '#', active: true),
             )
             ->listId(false)
             ->render();
@@ -64,9 +64,9 @@ final class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
             ->ariaLabel('Basic example of breadcrumbs')
             ->addClass('test-class', null, BackgroundColor::PRIMARY)
             ->links(
-                new Link('Home', '/'),
-                new Link('Library', '#', active: true),
-                new Link('Data', '#'),
+                BreadcrumbLink::to('Home', '/'),
+                BreadcrumbLink::to('Library', '#', active: true),
+                BreadcrumbLink::to('Data', '#'),
             )
             ->listId(false);
 
@@ -113,9 +113,9 @@ final class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
                 ->addAttributes(['data-test' => 'test'])
                 ->ariaLabel('Basic example of breadcrumbs')
                 ->links(
-                    new Link('Home', '/'),
-                    new Link('Library', '#'),
-                    new Link('Data', active: true),
+                    BreadcrumbLink::to('Home', '/'),
+                    BreadcrumbLink::to('Library', '#'),
+                    BreadcrumbLink::to('Data', active: true),
                 )
                 ->listId(false)
                 ->render(),
@@ -137,9 +137,9 @@ final class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
             Breadcrumbs::widget()
                 ->ariaLabel('Basic example of breadcrumbs')
                 ->links(
-                    new Link('Home', '/'),
-                    new Link('Library', '#'),
-                    new Link('Data', active: true),
+                    BreadcrumbLink::to('Home', '/'),
+                    BreadcrumbLink::to('Library', '#'),
+                    BreadcrumbLink::to('Data', active: true),
                 )
                 ->listId(false)
                 ->render(),
@@ -161,9 +161,9 @@ final class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
             Breadcrumbs::widget()
                 ->attributes(['class' => 'test-class'])
                 ->links(
-                    new Link('Home', '/'),
-                    new Link('Library', '#'),
-                    new Link('Data', active: true),
+                    BreadcrumbLink::to('Home', '/'),
+                    BreadcrumbLink::to('Library', '#'),
+                    BreadcrumbLink::to('Data', active: true),
                 )
                 ->listId(false)
                 ->render(),
@@ -186,9 +186,9 @@ final class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
                 ->addClass('test-class')
                 ->class('custom-class', 'another-class', BackgroundColor::PRIMARY)
                 ->links(
-                    new Link('Home', '/'),
-                    new Link('Library', '#'),
-                    new Link('Data', active: true),
+                    BreadcrumbLink::to('Home', '/'),
+                    BreadcrumbLink::to('Library', '#'),
+                    BreadcrumbLink::to('Data', active: true),
                 )
                 ->listId(false)
                 ->render(),
@@ -213,9 +213,9 @@ final class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
             Breadcrumbs::widget()
                 ->divider('>')
                 ->links(
-                    new Link('Home', '/'),
-                    new Link('Library', '#'),
-                    new Link('Data', active: true),
+                    BreadcrumbLink::to('Home', '/'),
+                    BreadcrumbLink::to('Library', '#'),
+                    BreadcrumbLink::to('Data', active: true),
                 )
                 ->listId(false)
                 ->render(),
@@ -243,7 +243,7 @@ final class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
         $this->assertNotSame($breacrumb, $breacrumb->itemActiveClass(''));
         $this->assertNotSame($breacrumb, $breacrumb->itemAttributes([]));
         $this->assertNotSame($breacrumb, $breacrumb->linkAttributes([]));
-        $this->assertNotSame($breacrumb, $breacrumb->links(new Link()));
+        $this->assertNotSame($breacrumb, $breacrumb->links(BreadcrumbLink::to('tests')));
         $this->assertNotSame($breacrumb, $breacrumb->listAttributes([]));
         $this->assertNotSame($breacrumb, $breacrumb->listId(''));
         $this->assertNotSame($breacrumb, $breacrumb->listTagName(''));
@@ -263,9 +263,9 @@ final class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
             HTML,
             Breadcrumbs::widget()
                 ->links(
-                    new Link('Home', '/'),
-                    new Link('Library', '#'),
-                    new Link('Data', active: true),
+                    BreadcrumbLink::to('Home', '/'),
+                    BreadcrumbLink::to('Library', '#'),
+                    BreadcrumbLink::to('Data', active: true),
                 )
                 ->itemActiveClass('test-active-class')
                 ->listId(false)
@@ -287,9 +287,9 @@ final class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
             HTML,
             Breadcrumbs::widget()
                 ->links(
-                    new Link('Home', '/'),
-                    new Link('Library', '#'),
-                    new Link('Data', active: true),
+                    BreadcrumbLink::to('Home', '/'),
+                    BreadcrumbLink::to('Library', '#'),
+                    BreadcrumbLink::to('Data', active: true),
                 )
                 ->itemAttributes(['class' => 'test-item-class'])
                 ->listId(false)
@@ -312,9 +312,9 @@ final class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
             Breadcrumbs::widget()
                 ->linkAttributes(['class' => 'test-link-class'])
                 ->links(
-                    new Link('Home', '/'),
-                    new Link('Library', '#'),
-                    new Link('Data', active: true),
+                    BreadcrumbLink::to('Home', '/'),
+                    BreadcrumbLink::to('Library', '#'),
+                    BreadcrumbLink::to('Data', active: true),
                 )
                 ->listId(false)
                 ->render(),
@@ -336,9 +336,9 @@ final class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
             Breadcrumbs::widget()
                 ->linkAttributes(['class' => 'test-link-class'])
                 ->links(
-                    new Link('Home', '/', attributes: ['data-test' => 'test']),
-                    new Link('Library', '#'),
-                    new Link('Data', active: true),
+                    BreadcrumbLink::to('Home', '/', attributes: ['data-test' => 'test']),
+                    BreadcrumbLink::to('Library', '#'),
+                    BreadcrumbLink::to('Data', active: true),
                 )
                 ->listId(false)
                 ->render(),
@@ -359,9 +359,9 @@ final class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
             HTML,
             Breadcrumbs::widget()
                 ->links(
-                    new Link('Home', '/'),
-                    new Link('Library', '#'),
-                    new Link('Data', active: true),
+                    BreadcrumbLink::to('Home', '/'),
+                    BreadcrumbLink::to('Library', '#'),
+                    BreadcrumbLink::to('Data', active: true),
                 )
                 ->listAttributes(['class' => 'test-list-class'])
                 ->listId(false)
@@ -383,9 +383,9 @@ final class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
             HTML,
             Breadcrumbs::widget()
                 ->links(
-                    new Link('Home', '/'),
-                    new Link('Library', '#'),
-                    new Link('Data', active: true),
+                    BreadcrumbLink::to('Home', '/'),
+                    BreadcrumbLink::to('Library', '#'),
+                    BreadcrumbLink::to('Data', active: true),
                 )
                 ->listId('test-id')
                 ->render(),
@@ -406,9 +406,9 @@ final class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
             HTML,
             Breadcrumbs::widget()
                 ->links(
-                    new Link('Home', '/'),
-                    new Link('Library', '#'),
-                    new Link('Data', active: true),
+                    BreadcrumbLink::to('Home', '/'),
+                    BreadcrumbLink::to('Library', '#'),
+                    BreadcrumbLink::to('Data', active: true),
                 )
                 ->listId('')
                 ->render(),
@@ -429,9 +429,9 @@ final class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
             HTML,
             Breadcrumbs::widget()
                 ->links(
-                    new Link('Home', '/'),
-                    new Link('Library', '#'),
-                    new Link('Data', active: true),
+                    BreadcrumbLink::to('Home', '/'),
+                    BreadcrumbLink::to('Library', '#'),
+                    BreadcrumbLink::to('Data', active: true),
                 )
                 ->listId(false)
                 ->render(),
@@ -452,9 +452,9 @@ final class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
             HTML,
             Breadcrumbs::widget()
                 ->links(
-                    new Link('Home', '/'),
-                    new Link('Library', '#'),
-                    new Link('Data', active: true),
+                    BreadcrumbLink::to('Home', '/'),
+                    BreadcrumbLink::to('Library', '#'),
+                    BreadcrumbLink::to('Data', active: true),
                 )
                 ->listAttributes(['id' => 'test-id'])
                 ->render(),
@@ -475,9 +475,9 @@ final class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
             HTML,
             Breadcrumbs::widget()
                 ->links(
-                    new Link('Home', '/'),
-                    new Link('Library', '#'),
-                    new Link('Data', active: true),
+                    BreadcrumbLink::to('Home', '/'),
+                    BreadcrumbLink::to('Library', '#'),
+                    BreadcrumbLink::to('Data', active: true),
                 )
                 ->listId(false)
                 ->listTagName('footer')
@@ -492,9 +492,9 @@ final class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
 
         Breadcrumbs::widget()
             ->links(
-                new Link('Home', '/'),
-                new Link('Library', '#'),
-                new Link('Data', active: true),
+                BreadcrumbLink::to('Home', '/'),
+                BreadcrumbLink::to('Library', '#'),
+                BreadcrumbLink::to('Data', active: true),
             )
             ->listTagName('')
             ->render();
@@ -522,9 +522,9 @@ final class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
             HTML,
             Breadcrumbs::widget()
                 ->links(
-                    new Link('Home', '#'),
-                    new Link('Library', '#'),
-                    new Link('Data', active: true),
+                    BreadcrumbLink::to('Home', '#'),
+                    BreadcrumbLink::to('Library', '#'),
+                    BreadcrumbLink::to('Data', active: true),
                 )
                 ->listId(false)
                 ->render(),

--- a/tests/BreadcrumbsTest.php
+++ b/tests/BreadcrumbsTest.php
@@ -195,6 +195,52 @@ final class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    public function testEncodeLabel(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <nav aria-label="breadcrumb">
+            <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a href="/">Home</a></li>
+            <li class="breadcrumb-item"><a href="#">Library</a></li>
+            <li class="breadcrumb-item active" aria-current="page">&lt;b&gt;Data&lt;/b&gt;</li>
+            </ol>
+            </nav>
+            HTML,
+            Breadcrumbs::widget()
+                ->links(
+                    BreadcrumbLink::to('Home', '/'),
+                    BreadcrumbLink::to('Library', '#'),
+                    BreadcrumbLink::to('<b>Data</b>', active: true),
+                )
+                ->listId(false)
+                ->render(),
+            );
+    }
+
+    public function testEncodeLabelWithFalseValue(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <nav aria-label="breadcrumb">
+            <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a href="/">Home</a></li>
+            <li class="breadcrumb-item"><a href="#">Library</a></li>
+            <li class="breadcrumb-item active" aria-current="page"><b>Data</b></li>
+            </ol>
+            </nav>
+            HTML,
+            Breadcrumbs::widget()
+                ->links(
+                    BreadcrumbLink::to('Home', '/'),
+                    BreadcrumbLink::to('Library', '#'),
+                    BreadcrumbLink::to('<b>Data</b>', active: true, encodeLabel: false),
+                )
+                ->listId(false)
+                ->render(),
+            );
+    }
+
     /**
      * @link https://getbootstrap.com/docs/5.2/components/breadcrumb/#dividers
      */

--- a/tests/BreadcrumbsTest.php
+++ b/tests/BreadcrumbsTest.php
@@ -60,7 +60,7 @@ final class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
 
     public function testAddCssClass(): void
     {
-        $alert = Breadcrumbs::widget()
+        $breadcrumb = Breadcrumbs::widget()
             ->ariaLabel('Basic example of breadcrumbs')
             ->addClass('test-class', null, BackgroundColor::PRIMARY)
             ->links(
@@ -80,7 +80,7 @@ final class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
             </ol>
             </nav>
             HTML,
-            $alert->render(),
+            $breadcrumb->render(),
         );
 
         Assert::equalsWithoutLE(
@@ -93,7 +93,85 @@ final class BreadcrumbsTest extends \PHPUnit\Framework\TestCase
             </ol>
             </nav>
             HTML,
-            $alert->addClass('test-class-1', 'test-class-2')->render(),
+            $breadcrumb->addClass('test-class-1', 'test-class-2')->render(),
+        );
+    }
+
+    public function testAddCssStyle(): void
+    {
+        $breadcrumb = Breadcrumbs::widget()
+            ->addCssStyle('color: red;')
+            ->ariaLabel('Basic example of breadcrumbs')
+            ->links(
+                BreadcrumbLink::to('Home', '/'),
+                BreadcrumbLink::to('Library', '#', active: true),
+                BreadcrumbLink::to('Data', '#'),
+            )
+            ->listId(false);
+
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <nav style="color: red;" aria-label="Basic example of breadcrumbs">
+            <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a href="/">Home</a></li>
+            <li class="breadcrumb-item active" aria-current="page"><a href="#">Library</a></li>
+            <li class="breadcrumb-item"><a href="#">Data</a></li>
+            </ol>
+            </nav>
+            HTML,
+            $breadcrumb->render(),
+        );
+
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <nav style="color: red; font-weight: bold;" aria-label="Basic example of breadcrumbs">
+            <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a href="/">Home</a></li>
+            <li class="breadcrumb-item active" aria-current="page"><a href="#">Library</a></li>
+            <li class="breadcrumb-item"><a href="#">Data</a></li>
+            </ol>
+            </nav>
+            HTML,
+            $breadcrumb->addCssStyle('font-weight: bold;')->render(),
+        );
+    }
+
+    public function testAddCssStyleWithOverwriteFalse(): void
+    {
+        $breadcrumb = Breadcrumbs::widget()
+            ->addCssStyle('color: red;')
+            ->ariaLabel('Basic example of breadcrumbs')
+            ->links(
+                BreadcrumbLink::to('Home', '/'),
+                BreadcrumbLink::to('Library', '#', active: true),
+                BreadcrumbLink::to('Data', '#'),
+            )
+            ->listId(false);
+
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <nav style="color: red;" aria-label="Basic example of breadcrumbs">
+            <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a href="/">Home</a></li>
+            <li class="breadcrumb-item active" aria-current="page"><a href="#">Library</a></li>
+            <li class="breadcrumb-item"><a href="#">Data</a></li>
+            </ol>
+            </nav>
+            HTML,
+            $breadcrumb->render(),
+        );
+
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <nav style="color: red;" aria-label="Basic example of breadcrumbs">
+            <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a href="/">Home</a></li>
+            <li class="breadcrumb-item active" aria-current="page"><a href="#">Library</a></li>
+            <li class="breadcrumb-item"><a href="#">Data</a></li>
+            </ol>
+            </nav>
+            HTML,
+            $breadcrumb->addCssStyle('color: blue;', false)->render(),
         );
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
