### PR TITLE
Refactor methods in `Accordion`, `Breadcrumbs`, and `Button` classes to eliminate cloning and use `addClass()` and `attibute()` methods.

### DIFF
--- a/src/Accordion.php
+++ b/src/Accordion.php
@@ -272,10 +272,7 @@ final class Accordion extends Widget
      */
     public function flush(bool $enabled = true): self
     {
-        $new = clone $this;
-        $new->cssClasses['flush'] = $enabled ? 'accordion-flush' : null;
-
-        return $new;
+        return $this->addClass($enabled ? 'accordion-flush' : null);
     }
 
     /**

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -136,10 +136,7 @@ final class Breadcrumbs extends Widget
      */
     public function ariaLabel(string $label): self
     {
-        $new = clone $this;
-        $new->attributes['aria-label'] = $label;
-
-        return $new;
+        return $this->attribute('aria-label', $label);
     }
 
     /**
@@ -228,10 +225,7 @@ final class Breadcrumbs extends Widget
             throw new InvalidArgumentException('The "divider" cannot be empty.');
         }
 
-        $new = clone $this;
-        $new->attributes['style'] = ['--bs-breadcrumb-divider' => sprintf("'%s'", $content)];
-
-        return $new;
+        return $this->attribute('style', ['--bs-breadcrumb-divider' => sprintf("'%s'", $content)]);
     }
 
     /**

--- a/src/Button.php
+++ b/src/Button.php
@@ -171,12 +171,10 @@ final class Button extends Widget
      */
     public function active(bool $enabled = true): self
     {
-        $new = $this
-            ->toggle($enabled ? TogglerType::BUTTON : null)
-            ->attribute('aria-pressed', $enabled ? 'true' : null);
-        $new->cssClasses['active'] = $enabled ? 'active' : null;
-
-        return $new;
+        return $this
+            ->addClass($enabled ? 'active' : null)
+            ->attribute('aria-pressed', $enabled ? 'true' : null)
+            ->toggle($enabled ? TogglerType::BUTTON : null);
     }
 
     /**
@@ -267,10 +265,7 @@ final class Button extends Widget
      */
     public function ariaExpanded(bool $enabled = true): self
     {
-        $new = clone $this;
-        $new->attributes['aria-expanded'] = $enabled ? 'true' : 'false';
-
-        return $new;
+        return $this->attribute('aria-expanded', $enabled ? 'true' : 'false');
     }
 
     /**
@@ -351,10 +346,7 @@ final class Button extends Widget
      */
     public function disableTextWrapping(): self
     {
-        $new = clone $this;
-        $new->cssClasses['text-nowrap'] = 'text-nowrap';
-
-        return $new;
+        return $this->addClass('text-nowrap');
     }
 
     /**
@@ -437,10 +429,7 @@ final class Button extends Widget
      */
     public function size(ButtonSize|null $size): self
     {
-        $new = clone $this;
-        $new->cssClasses['size'] = $size?->value;
-
-        return $new;
+        return $this->addClass($size?->value);
     }
 
     /**

--- a/src/Button.php
+++ b/src/Button.php
@@ -172,9 +172,9 @@ final class Button extends Widget
     public function active(bool $enabled = true): self
     {
         return $this
+            ->toggle($enabled ? TogglerType::BUTTON : null)
             ->addClass($enabled ? 'active' : null)
-            ->attribute('aria-pressed', $enabled ? 'true' : null)
-            ->toggle($enabled ? TogglerType::BUTTON : null);
+            ->attribute('aria-pressed', $enabled ? 'true' : null);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
