### PR TITLE
Fix example usage in `Modal` documentation to reference `$modal` instead of `$dropdown`.

### DIFF
--- a/src/Modal.php
+++ b/src/Modal.php
@@ -121,7 +121,7 @@ final class Modal extends Widget
      *
      * Example usage:
      * ```php
-     * $dropdown->addCssStyle('color: red');
+     * $modal->addCssStyle('color: red');
      *
      * // or
      * $modal->addCssStyle(['color' => 'red', 'font-weight' => 'bold']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
