### PR TITLE
Update `Dropdown` class to use `ButtonVariant` instead of `DropdownTogglerVariant` class.

### DIFF
--- a/src/Dropdown.php
+++ b/src/Dropdown.php
@@ -31,7 +31,7 @@ use Yiisoft\Widget\Widget;
  *         DropdownItem::link('Separated link', '#'),
  *     )
  *     ->toggleContent('Toggle dropdown')
- *     ->toggleVariant(DropdownToggleVariant::DANGER)
+ *     ->toggleVariant(ButtonVariant::DANGER)
  *     ->toggleSplit()
  *     ->toggleSplitContent('Danger')
  *     ->toggleSizeLarge()
@@ -71,7 +71,7 @@ final class Dropdown extends Widget
     private string|null $togglerSize = null;
     private bool $togglerSplit = false;
     private string $togglerSplitContent = 'Action';
-    private DropdownTogglerVariant $togglerVariant = DropdownTogglerVariant::SECONDARY;
+    private ButtonVariant $togglerVariant = ButtonVariant::SECONDARY;
 
     /**
      * Adds a sets of attributes.
@@ -604,11 +604,11 @@ final class Dropdown extends Widget
     /**
      * Sets the variant for the toggler.
      *
-     * @param DropdownTogglerVariant $variant The variant for the toggler.
+     * @param ButtonVariant $variant The variant for the toggler.
      *
      * @return self A new instance with the specified variant for the toggler.
      */
-    public function togglerVariant(DropdownTogglerVariant $variant): self
+    public function togglerVariant(ButtonVariant $variant): self
     {
         $new = clone $this;
         $new->togglerVariant = $variant;

--- a/tests/DropdownTest.php
+++ b/tests/DropdownTest.php
@@ -9,12 +9,12 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Html\Tag\Button;
 use Yiisoft\Yii\Bootstrap5\ButtonSize;
+use Yiisoft\Yii\Bootstrap5\ButtonVariant;
 use Yiisoft\Yii\Bootstrap5\Dropdown;
 use Yiisoft\Yii\Bootstrap5\DropdownAlignment;
 use Yiisoft\Yii\Bootstrap5\DropdownAutoClose;
 use Yiisoft\Yii\Bootstrap5\DropdownDirection;
 use Yiisoft\Yii\Bootstrap5\DropdownItem;
-use Yiisoft\Yii\Bootstrap5\DropdownTogglerVariant;
 use Yiisoft\Yii\Bootstrap5\Tests\Support\Assert;
 use Yiisoft\Yii\Bootstrap5\Utility\BackgroundColor;
 
@@ -1080,7 +1080,7 @@ final class DropdownTest extends TestCase
         $this->assertNotSame($dropdownWidget, $dropdownWidget->togglerSplit(false));
         $this->assertNotSame($dropdownWidget, $dropdownWidget->togglerSplitContent(''));
         $this->assertNotSame($dropdownWidget, $dropdownWidget->togglerUrl(''));
-        $this->assertNotSame($dropdownWidget, $dropdownWidget->togglerVariant(DropdownTogglerVariant::DANGER));
+        $this->assertNotSame($dropdownWidget, $dropdownWidget->togglerVariant(ButtonVariant::DANGER));
     }
 
     /**
@@ -1471,7 +1471,7 @@ final class DropdownTest extends TestCase
                 )
                 ->togglerAsLink()
                 ->togglerContent('Dropdown link')
-                ->togglerVariant(DropdownTogglerVariant::DANGER)
+                ->togglerVariant(ButtonVariant::DANGER)
                 ->render(),
         );
     }
@@ -1869,7 +1869,7 @@ final class DropdownTest extends TestCase
                     DropdownItem::link('Separated link', '#'),
                 )
                 ->togglerContent('Toggle dropdown')
-                ->togglerVariant(DropdownTogglerVariant::DANGER)
+                ->togglerVariant(ButtonVariant::DANGER)
                 ->togglerSplit()
                 ->togglerSplitContent('Danger')
                 ->render(),
@@ -1916,7 +1916,7 @@ final class DropdownTest extends TestCase
                     DropdownItem::link('Separated link', '#'),
                 )
                 ->togglerContent('Toggle dropdown')
-                ->togglerVariant(DropdownTogglerVariant::DANGER)
+                ->togglerVariant(ButtonVariant::DANGER)
                 ->togglerSplit()
                 ->togglerSplitContent('Danger')
                 ->togglerSize(ButtonSize::LARGE)
@@ -1964,7 +1964,7 @@ final class DropdownTest extends TestCase
                 ->togglerContent('Toggle dropdown')
                 ->togglerSplit()
                 ->togglerSplitContent('Danger')
-                ->togglerVariant(DropdownTogglerVariant::DANGER)
+                ->togglerVariant(ButtonVariant::DANGER)
                 ->render(),
         );
     }
@@ -2010,7 +2010,7 @@ final class DropdownTest extends TestCase
                 ->togglerSize(ButtonSize::LARGE)
                 ->togglerSplit()
                 ->togglerSplitContent('Danger')
-                ->togglerVariant(DropdownTogglerVariant::DANGER)
+                ->togglerVariant(ButtonVariant::DANGER)
                 ->render(),
         );
     }
@@ -2056,7 +2056,7 @@ final class DropdownTest extends TestCase
                 ->togglerSize(ButtonSize::SMALL)
                 ->togglerSplit()
                 ->togglerSplitContent('Danger')
-                ->togglerVariant(DropdownTogglerVariant::DANGER)
+                ->togglerVariant(ButtonVariant::DANGER)
                 ->render(),
         );
     }
@@ -2104,7 +2104,7 @@ final class DropdownTest extends TestCase
                 ->togglerSize(ButtonSize::SMALL)
                 ->togglerSplit()
                 ->togglerSplitContent('Danger')
-                ->togglerVariant(DropdownTogglerVariant::DANGER)
+                ->togglerVariant(ButtonVariant::DANGER)
                 ->render(),
         );
     }

--- a/tests/DropdownTest.php
+++ b/tests/DropdownTest.php
@@ -1477,6 +1477,40 @@ final class DropdownTest extends TestCase
     }
 
     /**
+     * @link https://getbootstrap.com/docs/5.3/components/dropdowns/#single-button
+     */
+    public function testSingleButtonWithVariantOutlineDanger(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <a class="btn btn-outline-danger dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">Dropdown link</a>
+            <ul class="dropdown-menu">
+            <li>
+            <a class="dropdown-item" href="#">Action</a>
+            </li>
+            <li>
+            <a class="dropdown-item" href="#">Another action</a>
+            </li>
+            <li>
+            <a class="dropdown-item" href="#">Something else here</a>
+            </li>
+            </ul>
+            </div>
+            HTML,
+            Dropdown::widget()
+                ->items(
+                    DropdownItem::link('Action', '#'),
+                    DropdownItem::link('Another action', '#'),
+                    DropdownItem::link('Something else here', '#'),
+                )
+                ->togglerAsLink()
+                ->togglerContent('Dropdown link')
+                ->togglerVariant(ButtonVariant::OUTLINE_DANGER)
+                ->render(),
+        );
+    }
+
+    /**
      * @link https://getbootstrap.com/docs/5.3/customize/color-modes/
      */
     public function testThemeLight(): void

--- a/tests/DropdownTest.php
+++ b/tests/DropdownTest.php
@@ -1483,6 +1483,7 @@ final class DropdownTest extends TestCase
     {
         Assert::equalsWithoutLE(
             <<<HTML
+            <div class="dropdown">
             <a class="btn btn-outline-danger dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">Dropdown link</a>
             <ul class="dropdown-menu">
             <li>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
